### PR TITLE
Update INT type for numpy 2.0

### DIFF
--- a/pyearth/_types.pxd
+++ b/pyearth/_types.pxd
@@ -1,5 +1,5 @@
 cimport numpy as cnp
 ctypedef cnp.float64_t FLOAT_t
-ctypedef cnp.int_t INT_t
+ctypedef cnp.intp_t INT_t
 ctypedef cnp.intp_t INDEX_t
 ctypedef cnp.uint8_t BOOL_t

--- a/pyearth/_types.pyx
+++ b/pyearth/_types.pyx
@@ -1,5 +1,5 @@
 import numpy as np
 FLOAT = np.float64
-INT = np.int
+INT = np.intp
 INDEX = np.intp
 BOOL = np.uint8


### PR DESCRIPTION
## Summary
- use `cnp.intp_t` for `INT_t` ctypedef
- use `np.intp` for the `INT` dtype
- verified `_types` builds with Cython

## Testing
- `cython pyearth/_types.pyx`
- `python - <<'PY'
from setuptools import setup, Extension
import numpy
setup(name='dummy', ext_modules=[Extension('pyearth._types', ['pyearth/_types.c'], include_dirs=[numpy.get_include()])], script_args=['build_ext', '--inplace'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68678a0389bc8331bfa7a06477711cdb