### PR TITLE
Add contributing guide for building Cython extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to py-earth
+
+Thank you for considering contributing to py-earth!
+
+## Building Cython extensions
+
+The test suite requires the Cython extensions to be compiled. Before running the
+tests, build the extensions in place with one of the following commands:
+
+```bash
+pip install -e .
+# or
+python setup.py build_ext --inplace
+```
+
+After the extensions are built you can run the test suite, e.g. with `make test`
+or directly using `nosetests`.


### PR DESCRIPTION
## Summary
- document how to build the Cython modules before running tests in new `CONTRIBUTING.md`

## Testing
- `nosetests -s pyearth` *(fails: ModuleNotFoundError: No module named 'imp')*

------
https://chatgpt.com/codex/tasks/task_e_686789f35fd08331967a0f5a151be4e0