### PR TITLE
Replace iteritems/itervalues with items/values

### DIFF
--- a/pyearth/_basis.pyx
+++ b/pyearth/_basis.pyx
@@ -986,7 +986,7 @@ cdef class Basis:
         cdef dict anova = self.anova_decomp()
         cdef dict intermediate = {}
         cdef dict result = {}
-        for vars, bfs in anova.iteritems():
+        for vars, bfs in anova.items():
             intermediate[vars] = {}
             for var in vars:
                 intermediate[vars][var] = []
@@ -995,8 +995,8 @@ cdef class Basis:
                     variable = bf.get_variable()
                     knot = bf.get_knot()
                     intermediate[vars][variable].append((bf, knot))
-        for d in intermediate.itervalues():
-            for var, lst in d.iteritems():
+        for d in intermediate.values():
+            for var, lst in d.items():
                 lst.sort(key=lambda x: x[1])
                 prev_minus = mins[var]
                 prev = prev_minus

--- a/pyearth/test/test_earth.py
+++ b/pyearth/test/test_earth.py
@@ -259,7 +259,7 @@ def test_pathological_cases():
                           'endspan': 1,
                           'check_every': 1,
                           'sample_weight': 'issue_50_weight.csv'}}
-    for case, settings in cases.iteritems():
+    for case, settings in cases.items():
         data = pandas.read_csv(os.path.join(directory, case + '.csv'))
         y = data['y']
         del data['y']


### PR DESCRIPTION
## Summary
- modernize dictionary iteration to work on Python 3

## Testing
- `pip install -e .` *(fails: `longintrepr.h` missing)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_686789ef097c8331b98aa2f4dca9c634