### PR TITLE
Remove stray print from QR Cython code

### DIFF
--- a/pyearth/_qr.pyx
+++ b/pyearth/_qr.pyx
@@ -198,8 +198,7 @@ cdef class Householder:
         cdef int ldc = C.strides[1] // C.itemsize
         cdef FLOAT_t * work = <FLOAT_t *> &(self.work[0,0])
         cdef int ldwork = self.m
-        print C.shape
-        dlarfb(&side, &trans, &direct, &storev, &M, &N, &K, 
+        dlarfb(&side, &trans, &direct, &storev, &M, &N, &K,
                V, &ldv, T, &ldt, C_arg, &ldc, work, &ldwork)
         
     cpdef void left_apply_transpose(Householder self, FLOAT_t[::1, :] C):


### PR DESCRIPTION
## Summary
- clean up unwanted console output in Householder.left_apply

## Testing
- `pytest -q pyearth/test/test_qr.py -k ''` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_686789e9dcb48331bd1342b005f62f11