### PR TITLE
docs: mention build step before pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ cd py-earth
 sudo python setup.py install
 ```
 
+## Running Tests
+
+If you plan to run the unit tests, compile the C extensions first so that
+`pytest` can import the compiled modules:
+
+```bash
+python setup.py build_ext --inplace  # or `make inplace`
+pytest
+```
+
 ## Usage
 ```python
 import numpy


### PR DESCRIPTION
## Summary
- add 'Running Tests' section in README
- clarify that `python setup.py build_ext --inplace` or `make inplace` is required before `pytest`

## Testing
- `python setup.py build_ext --inplace` *(fails: longintrepr.h missing)*
- `make inplace` *(fails: longintrepr.h missing)*
- `pytest` *(fails: ModuleNotFoundError: pyearth._forward)*

------
https://chatgpt.com/codex/tasks/task_e_6867882ff5c8833197ed5f06db27ad7f