### PR TITLE
Ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ examples/classifier_comp.pdf
 examples/comparison.csv
 scripts/comparison.csv
 py_earth.egg-info
+
+.pytest_cache/


### PR DESCRIPTION
## Summary
- ignore `.pytest_cache` from version control

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_6867882e79748331aff5c36d51446090