### PR TITLE
Modernize numpy dtype usage in Cython

### DIFF
--- a/pyearth/_forward.pyx
+++ b/pyearth/_forward.pyx
@@ -108,10 +108,10 @@ cdef class ForwardPasser:
             content = FastHeapContent(idx=0)
             heappush(self.fast_heap, content)
             
-        self.mwork = np.empty(shape=self.m, dtype=np.int)
+        self.mwork = np.empty(shape=self.m, dtype=np.int_)
         
         self.B = np.ones(
-            shape=(self.m, self.max_terms + 4), order='F', dtype=np.float)
+            shape=(self.m, self.max_terms + 4), order='F', dtype=np.float64)
         self.basis.transform(self.X, self.missing, self.B[:,0:1])
         
         if self.endspan < 0:
@@ -172,7 +172,7 @@ cdef class ForwardPasser:
             <cnp.ndarray[FLOAT_t, ndim = 2] > self.X)
         cdef ConstantBasisFunction root_basis_function = self.basis[0]
         for variable in range(self.n):
-            order = np.argsort(X[:, variable])[::-1].astype(np.int)
+            order = np.argsort(X[:, variable])[::-1].astype(np.int_)
             if root_basis_function.valid_knots(B[order, 0], X[order, variable],
                                                variable, self.check_every,
                                                self.endspan, self.minspan,

--- a/pyearth/_knot_search.pyx
+++ b/pyearth/_knot_search.pyx
@@ -151,7 +151,7 @@ cdef class SingleOutcomeDependentData:
     @classmethod
     def alloc(cls, FLOAT_t[:] y, SingleWeightDependentData weight, INDEX_t m, INDEX_t max_terms):
         cdef FLOAT_t[:] theta
-        cdef FLOAT_t[:] wy = np.empty(shape=m, dtype=np.float)
+        cdef FLOAT_t[:] wy = np.empty(shape=m, dtype=np.float64)
         cdef int i
         for i in range(m):
             wy[i] = weight.w[i] * y[i]
@@ -344,11 +344,11 @@ cdef class KnotSearchWorkingData:
     
     @classmethod
     def alloc(cls, int max_terms):
-        cdef FLOAT_t[:] gamma = np.empty(shape=max_terms, dtype=np.float)
-        cdef FLOAT_t[:] kappa = np.empty(shape=max_terms, dtype=np.float)
-        cdef FLOAT_t[:] delta_kappa = np.empty(shape=max_terms, dtype=np.float)
-        cdef FLOAT_t[:] chi = np.empty(shape=max_terms, dtype=np.float)
-        cdef FLOAT_t[:] psi = np.empty(shape=max_terms, dtype=np.float)
+        cdef FLOAT_t[:] gamma = np.empty(shape=max_terms, dtype=np.float64)
+        cdef FLOAT_t[:] kappa = np.empty(shape=max_terms, dtype=np.float64)
+        cdef FLOAT_t[:] delta_kappa = np.empty(shape=max_terms, dtype=np.float64)
+        cdef FLOAT_t[:] chi = np.empty(shape=max_terms, dtype=np.float64)
+        cdef FLOAT_t[:] psi = np.empty(shape=max_terms, dtype=np.float64)
         cdef INDEX_t q = 0
         cdef KnotSearchState state = KnotSearchState.alloc()
         return cls(gamma, kappa, delta_kappa, chi, psi, state)

--- a/pyearth/_pruning.pyx
+++ b/pyearth/_pruning.pyx
@@ -29,7 +29,7 @@ cdef class PruningPasser:
         self.sample_weight = sample_weight
         self.verbose = verbose
         self.basis = basis
-        self.B = np.empty(shape=(self.m, len(self.basis) + 1), dtype=np.float)
+        self.B = np.empty(shape=(self.m, len(self.basis) + 1), dtype=np.float64)
         self.penalty = kwargs.get('penalty', 3.0)
         if sample_weight.shape[1] == 1:
             y_avg = np.average(self.y, weights=sample_weight[:,0], axis=0)

--- a/pyearth/_types.pyx
+++ b/pyearth/_types.pyx
@@ -1,5 +1,5 @@
 import numpy as np
 FLOAT = np.float64
-INT = np.int
+INT = np.int_
 INDEX = np.intp
 BOOL = np.uint8


### PR DESCRIPTION
## Summary
- replace deprecated `np.int` alias with `np.int_`
- use explicit `np.float64` in cython sources

## Testing
- `python setup.py build_ext --inplace --cythonize` *(fails: `_basis.pxd:3:0: '_types.pxd' not found` and `longintrepr.h` missing)*
- `pytest -q` *(fails: ModuleNotFoundError for `pyearth._forward`)*

------
https://chatgpt.com/codex/tasks/task_e_6867791bafa0833193023d53bd2941ce