### PR TITLE
Fix deprecated Python syntax

### DIFF
--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -589,11 +589,7 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
             self.xlabels_ = xlabels
         if self.feature_importance_type is not None:
             feature_importance_type = self.feature_importance_type
-            try:
-                is_str = isinstance(feature_importance_type, basestring)
-            except NameError:
-                is_str = isinstance(feature_importance_type, str)
-            if is_str:
+            if isinstance(feature_importance_type, str):
                 feature_importance_type = [feature_importance_type]
             for k in feature_importance_type:
                 if k not in FEAT_IMP_CRITERIA:

--- a/pyearth/test/test_earth.py
+++ b/pyearth/test/test_earth.py
@@ -259,7 +259,7 @@ def test_pathological_cases():
                           'endspan': 1,
                           'check_every': 1,
                           'sample_weight': 'issue_50_weight.csv'}}
-    for case, settings in cases.iteritems():
+    for case, settings in cases.items():
         data = pandas.read_csv(os.path.join(directory, case + '.csv'))
         y = data['y']
         del data['y']

--- a/pyearth/test/testing_utils.py
+++ b/pyearth/test/testing_utils.py
@@ -2,7 +2,7 @@ import os
 from functools import wraps
 from nose import SkipTest
 from nose.tools import assert_almost_equal
-from distutils.version import LooseVersion
+from packaging.version import Version
 import sys
 
 def if_environ_has(var_name):
@@ -36,7 +36,7 @@ def if_sklearn_version_greater_than_or_equal_to(min_version):
         @wraps(func)
         def run_test(*args, **kwargs):
             import sklearn
-            if LooseVersion(sklearn.__version__) < LooseVersion(min_version):
+            if Version(sklearn.__version__) < Version(min_version):
                 raise SkipTest('sklearn version less than %s' %
                                str(min_version))
             else:


### PR DESCRIPTION
## Summary
- remove old `basestring` check in `earth.py`
- use `dict.items()` in tests
- replace `distutils.LooseVersion` with `packaging.Version`

## Testing
- `make test` *(fails: fatal error: longintrepr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6867791a98e88331b61d0035b2038071