### PR TITLE
Update conda recipe SciPy requirement

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,19 +12,20 @@ requirements:
     - cython
     - numpy
     - scikit-learn
+    - scipy >=0.16
     - nose
     - six
   run:
     - python
     - numpy
-    - scipy
+    - scipy >=0.16
     - scikit-learn
     - six
 
 test:
   requires:
     - numpy
-    - scipy
+    - scipy >=0.16
     - scikit-learn
     - nose
   imports:


### PR DESCRIPTION
## Summary
- enforce minimum SciPy version in conda build, run, and test requirements

## Testing
- `make test` *(fails to cythonize: 'FLOAT_t' is not a type identifier)*

------
https://chatgpt.com/codex/tasks/task_e_686775aeb1888331b30b9171a85c5807