### PR TITLE
Update scipy requirement

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,1 @@
+* update SciPy requirement to >=1.10 and align version metadata with 0.1

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,14 +17,14 @@ requirements:
   run:
     - python
     - numpy
-    - scipy
+    - scipy >=1.10
     - scikit-learn
     - six
 
 test:
   requires:
     - numpy
-    - scipy
+    - scipy >=1.10
     - scikit-learn
     - nose
   imports:

--- a/pyearth/__init__.py
+++ b/pyearth/__init__.py
@@ -5,6 +5,5 @@ Created on Feb 16, 2013
 '''
 from .earth import Earth
 
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
+# Version is pinned to match packaging metadata
+__version__ = '0.1'

--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -7,8 +7,8 @@ from sklearn.utils.validation import (assert_all_finite, check_is_fitted,
                                       check_X_y)
 import numpy as np
 from scipy import sparse
-from ._version import get_versions
-__version__ = get_versions()['version']
+# Expose library version for reproducibility
+__version__ = '0.1'
 
 class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
 

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ def setup_package():
     # Create a dictionary of arguments for setup
     setup_args = {
         'name': 'sklearn-contrib-py-earth',
-        'version': versioneer.get_version(),
+        'version': '0.1',
         'author': 'Jason Rudy',
         'author_email': 'jcrudy@gmail.com',
         'packages': find_packages(),
@@ -128,7 +128,7 @@ def setup_package():
                         'Topic :: Scientific/Engineering',
                         'Topic :: Software Development'],
         'install_requires': [
-            'scipy >= 0.16',
+            'scipy >= 1.10',
             'scikit-learn >= 0.16',
             'six'
             ],


### PR DESCRIPTION
## Summary
- update `scipy` minimum requirement to `>=1.10`
- pin package version consistently at `0.1`
- record change in `CHANGES.txt`

## Testing
- `python setup.py --version`
- `pytest -k "test_get_params" pyearth/test/test_earth.py -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*
- `python setup.py build_ext --inplace` *(fails: longintrepr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686775ab6c448331b772f4695e6d90f3