### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install cython nose numpy scipy pandas patsy statsmodels scikit-learn sympy
+      - name: Build extensions
+        run: |
+          python setup.py build_ext --inplace
+      - name: Run tests
+        run: |
+          nosetests -s -v pyearth


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on multiple Python versions

## Testing
- `python setup.py build_ext --inplace` *(fails: `longintrepr.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686775a925dc83318d25c16c217134ee