### PR TITLE
Attempt check_estimator compatibility

### DIFF
--- a/pyearth/_types.pxd
+++ b/pyearth/_types.pxd
@@ -1,5 +1,4 @@
-cimport numpy as cnp
-ctypedef cnp.float64_t FLOAT_t
-ctypedef cnp.int_t INT_t
-ctypedef cnp.intp_t INDEX_t
-ctypedef cnp.uint8_t BOOL_t
+ctypedef double FLOAT_t
+ctypedef long INT_t
+ctypedef Py_ssize_t INDEX_t
+ctypedef unsigned char BOOL_t

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,12 @@ def get_ext_modules():
                  include_dirs=[local_inc,
                                numpy_inc]),
              Extension(
-                 "pyearth._types",
-                 ["pyearth/_types.pyx"],
-                 include_dirs=[local_inc,
-                               numpy_inc])
-             ])
+                "pyearth._types",
+                ["pyearth/_types.pyx"],
+                include_dirs=[local_inc,
+                              numpy_inc])
+             ],
+            include_path=[local_inc])
     else:
         ext_modules = [Extension(
             "pyearth._util", ["pyearth/_util.c"], include_dirs=[numpy_inc]),
@@ -93,6 +94,11 @@ def get_ext_modules():
                 include_dirs=[local_inc,
                               numpy_inc])
         ]
+    if sys.version_info >= (3, 12):
+        for ext in ext_modules:
+            macros = dict(ext.define_macros)
+            macros['CYTHON_USE_PYLONG_INTERNALS'] = '0'
+            ext.define_macros = list(macros.items())
     return ext_modules
 
 def setup_package():


### PR DESCRIPTION
## Summary
- modify Cython types to avoid numpy headers
- add Python 3.12 build macro to disable PyLong internals
- scrub complex data and drop zero-weight samples in Earth

## Testing
- `python setup.py build_ext --inplace --cythonize`
- `python - <<'EOF'
from sklearn.utils.estimator_checks import check_estimator
from pyearth import Earth
check_estimator(Earth())
print('OK')
EOF` *(fails: AssertionError: expected 1 DataConversionWarning)*

------
https://chatgpt.com/codex/tasks/task_e_686775a7ac2083318db6de7220d5689f