### PR TITLE
Add sklearn parameter accessors

### DIFF
--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -325,6 +325,18 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
         self.verbose = verbose
         self._version = __version__
 
+    # ------------------------------------------------------------------
+    # Scikit-learn compatibility helpers
+    # ------------------------------------------------------------------
+    def get_params(self, deep=True):
+        """Return estimator parameters for ``GridSearchCV``."""
+        return super().get_params(deep=deep)
+
+    def set_params(self, **params):
+        """Set estimator parameters for ``GridSearchCV``."""
+        super().set_params(**params)
+        return self
+
     def __eq__(self, other):
         if self.__class__ is not other.__class__:
             return False

--- a/pyearth/test/test_earth.py
+++ b/pyearth/test/test_earth.py
@@ -88,6 +88,14 @@ def test_get_params():
                                          'verbose': False})
 
 
+def test_set_params():
+    model = Earth().set_params(max_degree=2, enable_pruning=False)
+    assert_equal(model.max_degree, 2)
+    assert_equal(model.enable_pruning, False)
+    assert_equal(model.get_params()['max_degree'], 2)
+    assert_equal(model.get_params()['enable_pruning'], False)
+
+
 @if_statsmodels
 def test_linear_fit():
     from statsmodels.regression.linear_model import GLS, OLS


### PR DESCRIPTION
## Summary
- expose compatibility wrappers for `get_params` and `set_params`
- cover `set_params` with a simple test

## Testing
- `pytest pyearth/test/test_set_params -q` *(fails: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_686775a69cc4833185de72ec4411691d