### PR TITLE
Update setup.py dependencies and classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,25 +118,26 @@ def setup_package():
                         'Operating System :: Unix',
                         'Programming Language :: Cython',
                         'Programming Language :: Python',
-                        'Programming Language :: Python :: 2',
-                        'Programming Language :: Python :: 2.6',
-                        'Programming Language :: Python :: 2.7',
                         'Programming Language :: Python :: 3',
-                        'Programming Language :: Python :: 3.4',
-                        'Programming Language :: Python :: 3.5',
-                        'Programming Language :: Python :: 3.6',
+                        'Programming Language :: Python :: 3 :: Only',
+                        'Programming Language :: Python :: 3.7',
+                        'Programming Language :: Python :: 3.8',
+                        'Programming Language :: Python :: 3.9',
+                        'Programming Language :: Python :: 3.10',
+                        'Programming Language :: Python :: 3.11',
                         'Topic :: Scientific/Engineering',
                         'Topic :: Software Development'],
         'install_requires': [
-            'scipy >= 0.16',
-            'scikit-learn >= 0.16',
-            'six'
+            'numpy>=1.17',
+            'scipy>=1.5',
+            'scikit-learn>=0.24',
+            'six>=1.15'
             ],
         'extras_require': {'docs': ['sphinx_gallery'],
                            'dev': ['cython'],
                            'export': ['sympy'],
                            'all_tests': ['pandas', 'statsmodels', 'patsy', 'sympy']},
-        'setup_requires': ['numpy'],
+        'setup_requires': ['numpy>=1.17'],
         'include_package_data': True
     }
 


### PR DESCRIPTION
## Summary
- update install requirements to modern versions
- limit Python versions to 3.7+

## Testing
- `python setup.py --version`
- `make test` *(fails: 'INDEX_t' is not a type identifier)*

------
https://chatgpt.com/codex/tasks/task_e_686775a1e66c8331bd0c3757d74bec91