### PR TITLE
Apply pyupgrade & 2to3

### DIFF
--- a/benchmarks/fast.py
+++ b/benchmarks/fast.py
@@ -35,8 +35,8 @@ hp = dict(
 model_normal = Earth(**hp)
 t = Timer(lambda: model_normal.fit(inputs, outputs))
 duration_normal = t.timeit(number=1)
-print("Normal : MSE={0:.5f}, duration={1:.2f}s".
-      format(model_normal.mse_, duration_normal))
+print(("Normal : MSE={0:.5f}, duration={1:.2f}s".
+      format(model_normal.mse_, duration_normal)))
 model_fast = Earth(use_fast=True,
                    fast_K=5,
                    fast_h=1,
@@ -44,9 +44,9 @@ model_fast = Earth(use_fast=True,
 
 t = Timer(lambda: model_fast.fit(inputs, outputs))
 duration_fast = t.timeit(number=1)
-print("Fast: MSE={0:.5f}, duration={1:.2f}s".
-      format(model_fast.mse_, duration_fast))
+print(("Fast: MSE={0:.5f}, duration={1:.2f}s".
+      format(model_fast.mse_, duration_fast)))
 speedup = duration_normal / duration_fast
-print("diagnostic : MSE goes from {0:.5f} to {1:.5f} but it "
+print(("diagnostic : MSE goes from {0:.5f} to {1:.5f} but it "
       "is {2:.2f}x faster".
-      format(model_normal.mse_, model_fast.mse_, speedup))
+      format(model_normal.mse_, model_fast.mse_, speedup)))

--- a/benchmarks/pyearth_vs_earth.py
+++ b/benchmarks/pyearth_vs_earth.py
@@ -162,7 +162,7 @@ def compare(generator_class, sample_sizes, dimensions, repetitions, **kwargs):
         generator = generator_class(n=n)
         for m in sample_sizes:
             for rep in range(repetitions):
-                print n, m, rep
+                print((n, m, rep))
                 X, y = generator.generate(m=m)
                 y_pred_r, time_r, iter_r = run_earth(X, y, **kwargs)
                 rsq_r = 1 - (numpy.sum((y - y_pred_r) ** 2)) / (
@@ -187,5 +187,5 @@ if __name__ == '__main__':
         rep,
         max_degree=2,
         penalty=3.0)
-    print data
+    print(data)
     data.to_csv('comparison.csv')

--- a/conda-recipe/move-conda-package.py
+++ b/conda-recipe/move-conda-package.py
@@ -9,7 +9,7 @@ with open(os.path.join(sys.argv[1], 'meta.yaml')) as f:
     name = yaml.load(f)['package']['name']
 
 binary_package_glob = os.path.join(
-    config.bldpkgs_dir, '{0}*.tar.bz2'.format(name))
+    config.bldpkgs_dir, '{}*.tar.bz2'.format(name))
 binary_package = glob.glob(binary_package_glob)[0]
 
 shutil.move(binary_package, 'dist')

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # py-earth documentation build configuration file, created by
 # sphinx-quickstart on Thu Jul 11 21:44:49 2013.
@@ -57,8 +56,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'py-earth'
-copyright = u'2013, Jason Rudy'
+project = 'py-earth'
+copyright = '2013, Jason Rudy'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -201,8 +200,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'py-earth.tex', u'py-earth Documentation',
-     u'Jason Rudy', 'manual'),
+    ('index', 'py-earth.tex', 'py-earth Documentation',
+     'Jason Rudy', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -231,8 +230,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'py-earth', u'py-earth Documentation',
-     [u'Jason Rudy'], 1)
+    ('index', 'py-earth', 'py-earth Documentation',
+     ['Jason Rudy'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -245,8 +244,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'py-earth', u'py-earth Documentation',
-     u'Jason Rudy', 'py-earth', 'One line description of project.',
+    ('index', 'py-earth', 'py-earth Documentation',
+     'Jason Rudy', 'py-earth', 'One line description of project.',
                     'Miscellaneous'),
 ]
 

--- a/doc/generate_figures.py
+++ b/doc/generate_figures.py
@@ -19,8 +19,8 @@ model = Earth()
 model.fit(X, y)
 
 # Print the model
-print(model.trace())
-print(model.summary())
+print((model.trace()))
+print((model.summary()))
 
 # Plot the model
 y_hat = model.predict(X)

--- a/doc/xkcdify.py
+++ b/doc/xkcdify.py
@@ -23,9 +23,9 @@ import matplotlib.font_manager as fm
 
 # We need a special font for the code below.  It can be downloaded this way:
 import os
-import urllib
+import urllib.request, urllib.parse, urllib.error
 if not os.path.exists('Humor-Sans.ttf'):
-    fhandle = urllib.urlopen('https://github.com/shreyankg/xkcd-desktop/raw/master/Humor-Sans.ttf')
+    fhandle = urllib.request.urlopen('https://github.com/shreyankg/xkcd-desktop/raw/master/Humor-Sans.ttf')
     open('Humor-Sans.ttf', 'wb').write(fhandle.read())
 
 

--- a/examples/plot_derivatives.py
+++ b/examples/plot_derivatives.py
@@ -26,8 +26,8 @@ model = Earth(max_degree=2, minspan_alpha=.5, smooth=True)
 model.fit(X, y)
 
 # Print the model
-print(model.trace())
-print(model.summary())
+print((model.trace()))
+print((model.summary()))
 
 # Get the predicted values and derivatives
 y_hat = model.predict(X)

--- a/examples/plot_feature_importance.py
+++ b/examples/plot_feature_importance.py
@@ -45,9 +45,9 @@ model.fit(X, y)
 rf = RandomForestRegressor()
 rf.fit(X, y)
 # Print the model
-print(model.trace())
-print(model.summary())
-print(model.summary_feature_importances(sort_by='gcv'))
+print((model.trace()))
+print((model.summary()))
+print((model.summary_feature_importances(sort_by='gcv')))
 
 # Plot the feature importances
 importances = model.feature_importances_
@@ -67,6 +67,6 @@ for crit in criteria:
     plt.title(crit)
     plt.ylabel('importances')
     idx += 1
-title = '$x_0,...x_9 \sim \mathcal{N}(0, 1)$\n$y= 10sin(\pi x_{0}x_{1}) + 20(x_2 - 0.5)^2 + 10x_3 + 5x_4 + Unif(0, 1)$'
+title = '$x_0,...x_9 \\sim \\mathcal{N}(0, 1)$\n$y= 10sin(\\pi x_{0}x_{1}) + 20(x_2 - 0.5)^2 + 10x_3 + 5x_4 + Unif(0, 1)$'
 fig.suptitle(title, fontsize="x-large")
 plt.show()

--- a/examples/plot_linear_function.py
+++ b/examples/plot_linear_function.py
@@ -26,7 +26,7 @@ y = 2 * X[:, 0] + 3 * X[:, 1] + np.random.normal(size=m)
 model = Earth().fit(X, y)
 
 # Print the model summary, showing linear terms
-print(model.summary())
+print((model.summary()))
 
 # Plot for both values of X[:,1]
 y_hat = model.predict(X)

--- a/examples/plot_missing_data_problem.py
+++ b/examples/plot_missing_data_problem.py
@@ -32,7 +32,7 @@ model = Earth(max_degree=5, minspan_alpha=.5, allow_missing=True,
               enable_pruning=True, thresh=.001, smooth=True, verbose=2)
 model.fit(X, y)
 # Print the model
-print(model.summary())
+print((model.summary()))
 
 # Plot the model
 y_hat = model.predict(X)

--- a/examples/plot_multicolumn.py
+++ b/examples/plot_multicolumn.py
@@ -39,8 +39,8 @@ model = Earth(max_degree=5, minspan_alpha=.5, allow_missing=True,
 model.fit(X, y)
 
 # Print the model
-print(model.trace())
-print(model.summary())
+print((model.trace()))
+print((model.summary()))
 
 # Plot the model
 y_hat = model.predict(X)

--- a/examples/plot_output_weight.py
+++ b/examples/plot_output_weight.py
@@ -39,21 +39,21 @@ for i, alpha in enumerate(alphas):
                   thresh=0.)
     output_weight = np.array([alpha, 1 - alpha])
     model.fit(X, y_mix, output_weight=output_weight)
-    print(model.summary())
+    print((model.summary()))
 
     # Plot the model
     y_hat = model.predict(X)
 
     mse = ((y_hat - y_mix) ** 2).mean(axis=0)
     ax = plt.subplot(n_plots, 2, k)
-    ax.set_ylabel("Run {0}".format(i + 1), rotation=0, labelpad=20)
+    ax.set_ylabel("Run {}".format(i + 1), rotation=0, labelpad=20)
     plt.plot(X[:, 6], y_mix[:, 0], 'r.')
     plt.plot(X[:, 6], model.predict(X)[:, 0], 'b.')
-    plt.title("MSE: {0:.3f}, Weight : {1:.1f}".format(mse[0], alpha))
+    plt.title("MSE: {:.3f}, Weight : {:.1f}".format(mse[0], alpha))
     plt.subplot(n_plots, 2, k + 1)
     plt.plot(X[:, 5], y_mix[:, 1], 'r.')
     plt.plot(X[:, 5], model.predict(X)[:, 1], 'b.')
-    plt.title("MSE: {0:.3f}, Weight : {1:.1f}".format(mse[1], 1 - alpha))
+    plt.title("MSE: {:.3f}, Weight : {:.1f}".format(mse[1], 1 - alpha))
     k += 2
 plt.tight_layout()
 plt.show()

--- a/examples/plot_sine_wave.py
+++ b/examples/plot_sine_wave.py
@@ -16,7 +16,7 @@ m = 10000
 n = 10
 X = 80 * numpy.random.uniform(size=(m, n)) - 40
 y = 100 * \
-    (numpy.sin((X[:, 6])) - 4.0) + \
+    (numpy.sin(X[:, 6]) - 4.0) + \
     10 * numpy.random.normal(size=m)
 
 # Fit an Earth model
@@ -24,8 +24,8 @@ model = Earth(max_degree=3, minspan_alpha=.5, verbose=True)
 model.fit(X, y)
 
 # Print the model
-print(model.trace())
-print(model.summary())
+print((model.trace()))
+print((model.summary()))
 
 # Plot the model
 y_hat = model.predict(X)

--- a/examples/plot_sine_wave_2d.py
+++ b/examples/plot_sine_wave_2d.py
@@ -29,8 +29,8 @@ y_mix = numpy.concatenate((y1[:, numpy.newaxis], y2[:, numpy.newaxis]), axis=1)
 model.fit(X, y_mix)
 
 # Print the model
-print(model.trace())
-print(model.summary())
+print((model.trace()))
+print((model.summary()))
 
 # Plot the model
 y_hat = model.predict(X)

--- a/examples/plot_v_function.py
+++ b/examples/plot_v_function.py
@@ -23,8 +23,8 @@ model = Earth(max_degree=1, verbose=True)
 model.fit(X, y)
 
 # Print the model
-print(model.trace())
-print(model.summary())
+print((model.trace()))
+print((model.summary()))
 
 # Plot the model
 y_hat = model.predict(X)

--- a/examples/return_sympy.py
+++ b/examples/return_sympy.py
@@ -17,16 +17,16 @@ m = 1000
 n = 10
 X = 10 * numpy.random.uniform(size=(m, n)) - 40
 y = 100 * \
-    (numpy.sin((X[:, 6])) - 4.0) + \
+    (numpy.sin(X[:, 6]) - 4.0) + \
     10 * numpy.random.normal(size=m)
 
 # Fit an Earth model
 model = Earth(max_degree=2, minspan_alpha=.5, verbose=False)
 model.fit(X, y)
 
-print(model.summary())
+print((model.summary()))
 
 #return sympy expression 
 print('Resulting sympy expression:')
-print(export.export_sympy(model))
+print((export.export_sympy(model)))
 

--- a/pyearth/_version.py
+++ b/pyearth/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -81,25 +80,25 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
                                  stderr=(subprocess.PIPE if hide_stderr
                                          else None))
             break
-        except EnvironmentError:
+        except OSError:
             e = sys.exc_info()[1]
             if e.errno == errno.ENOENT:
                 continue
             if verbose:
-                print("unable to run %s" % dispcmd)
+                print(("unable to run %s" % dispcmd))
                 print(e)
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(("unable to find command, tried {}".format(commands)))
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
         stdout = stdout.decode()
     if p.returncode != 0:
         if verbose:
-            print("unable to run %s (error)" % dispcmd)
-            print("stdout was %s" % stdout)
+            print(("unable to run %s (error)" % dispcmd))
+            print(("stdout was %s" % stdout))
         return None, p.returncode
     return stdout, p.returncode
 
@@ -124,8 +123,8 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(("Tried directories %s but none started with prefix %s" %
+              (str(rootdirs), parentdir_prefix)))
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -138,7 +137,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        f = open(versionfile_abs, "r")
+        f = open(versionfile_abs)
         for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
@@ -153,7 +152,7 @@ def git_get_keywords(versionfile_abs):
                 if mo:
                     keywords["date"] = mo.group(1)
         f.close()
-    except EnvironmentError:
+    except OSError:
         pass
     return keywords
 
@@ -177,11 +176,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         if verbose:
             print("keywords are unexpanded, not using")
         raise NotThisMethod("unexpanded keywords, not a git-archive tarball")
-    refs = set([r.strip() for r in refnames.strip("()").split(",")])
+    refs = {r.strip() for r in refnames.strip("()").split(",")}
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = {r[len(TAG):] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,17 +189,17 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = {r for r in refs if re.search(r'\d', r)}
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs - tags))
+            print(("discarding '%s', no digits" % ",".join(refs - tags)))
     if verbose:
-        print("likely tags: %s" % ",".join(sorted(tags)))
+        print(("likely tags: %s" % ",".join(sorted(tags))))
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix):]
             if verbose:
-                print("picking %s" % r)
+                print(("picking %s" % r))
             return {"version": r,
                     "full-revisionid": keywords["full"].strip(),
                     "dirty": False, "error": None,
@@ -229,7 +228,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
                           hide_stderr=True)
     if rc != 0:
         if verbose:
-            print("Directory %s not under git control" % root)
+            print(("Directory %s not under git control" % root))
         raise NotThisMethod("'git rev-parse --git-dir' returned error")
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
@@ -278,7 +277,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         if not full_tag.startswith(tag_prefix):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
-                print(fmt % (full_tag, tag_prefix))
+                print((fmt % (full_tag, tag_prefix)))
             pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
                                % (full_tag, tag_prefix))
             return pieces

--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -278,7 +278,7 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
 
     """
 
-    forward_pass_arg_names = set([
+    forward_pass_arg_names = {
         'max_terms', 'max_degree', 'allow_missing', 'penalty',
         'endspan_alpha', 'endspan',
         'minspan_alpha', 'minspan',
@@ -287,12 +287,12 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
         'use_fast', 'fast_K', 'fast_h',
         'feature_importance_type',
         'verbose'
-    ])
-    pruning_pass_arg_names = set([
+    }
+    pruning_pass_arg_names = {
         'penalty',
         'feature_importance_type',
         'verbose'
-    ])
+    }
 
     def __init__(self, max_terms=None, max_degree=None, allow_missing=False,
                  penalty=None, endspan_alpha=None, endspan=None,
@@ -590,7 +590,7 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
         if self.feature_importance_type is not None:
             feature_importance_type = self.feature_importance_type
             try:
-                is_str = isinstance(feature_importance_type, basestring)
+                is_str = isinstance(feature_importance_type, str)
             except NameError:
                 is_str = isinstance(feature_importance_type, str)
             if is_str:
@@ -923,7 +923,7 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
                 i += 1
         result += ascii_table(header, data)
         result += '\n'
-        result += 'MSE: %.4f, GCV: %.4f, RSQ: %.4f, GRSQ: %.4f' % (
+        result += 'MSE: {:.4f}, GCV: {:.4f}, RSQ: {:.4f}, GRSQ: {:.4f}'.format(
             self.mse_, self.gcv_, self.rsq_, self.grsq_)
         return result
 
@@ -944,16 +944,16 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
         """
         result = ''
         if self._feature_importances_dict:
-            max_label_length = max(map(len, self.xlabels_)) + 5
+            max_label_length = max(list(map(len, self.xlabels_))) + 5
             result += (max_label_length * ' ' +
-                       '    '.join(self._feature_importances_dict.keys()) + '\n')
+                       '    '.join(list(self._feature_importances_dict.keys())) + '\n')
             labels = np.array(self.xlabels_)
             if sort_by:
-                if sort_by not in self._feature_importances_dict.keys():
+                if sort_by not in list(self._feature_importances_dict.keys()):
                     raise ValueError('Invalid feature importance type name '
                                      'to sort with : %s, available : %s' % (
                                          sort_by,
-                                         self._feature_importances_dict.keys()))
+                                         list(self._feature_importances_dict.keys())))
                 imp = self._feature_importances_dict[sort_by]
                 indices = np.argsort(imp)[::-1]
             else:
@@ -961,7 +961,7 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
             labels = labels[indices]
             for i, label in enumerate(labels):
                 result += label + ' ' * (max_label_length - len(label))
-                for crit_name, imp in self._feature_importances_dict.items():
+                for crit_name, imp in list(self._feature_importances_dict.items()):
                     imp = imp[indices]
                     result += '%.2f' % imp[i] + (len(crit_name) ) * ' '
                 result += '\n'
@@ -1368,7 +1368,7 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
             return 3.0
 
 
-class EarthTrace(object):
+class EarthTrace:
 
     def __init__(self, forward_trace, pruning_trace):
         self.forward_trace = forward_trace

--- a/pyearth/export.py
+++ b/pyearth/export.py
@@ -132,7 +132,7 @@ def export_sympy_term_expressions(earth_model):
 
     def missingness_bf_get_missables(bf):
         bf_var = bf.label
-        return set([bf_var])
+        return {bf_var}
 
     def non_missable(bf):
         return set()

--- a/pyearth/test/basis/base.py
+++ b/pyearth/test/basis/base.py
@@ -2,7 +2,7 @@ import os
 import numpy
 
 
-class BaseContainer(object):
+class BaseContainer:
     filename = os.path.join(os.path.dirname(__file__), '../test_data.csv')
     data = numpy.genfromtxt(filename, delimiter=',', skip_header=1)
     X = numpy.array(data[:, 0:5])

--- a/pyearth/test/basis/test_basis.py
+++ b/pyearth/test/basis/test_basis.py
@@ -11,7 +11,7 @@ from pyearth._basis import (HingeBasisFunction, SmoothedHingeBasisFunction,
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.basis = Basis(self.X.shape[1])
         self.parent = ConstantBasisFunction()
         self.bf1 = HingeBasisFunction(self.parent, 1.0, 10, 1, False)
@@ -30,11 +30,11 @@ class Container(BaseContainer):
 def test_anova_decomp():
     cnt = Container()
     anova = cnt.basis.anova_decomp()
-    assert_equal(set(anova[frozenset([1])]), set([cnt.bf1]))
-    assert_equal(set(anova[frozenset([2])]), set([cnt.bf2, cnt.bf4,
-                                                  cnt.bf5]))
-    assert_equal(set(anova[frozenset([2, 3])]), set([cnt.bf3]))
-    assert_equal(set(anova[frozenset()]), set([cnt.parent]))
+    assert_equal(set(anova[frozenset([1])]), {cnt.bf1})
+    assert_equal(set(anova[frozenset([2])]), {cnt.bf2, cnt.bf4,
+                                                  cnt.bf5})
+    assert_equal(set(anova[frozenset([2, 3])]), {cnt.bf3})
+    assert_equal(set(anova[frozenset()]), {cnt.parent})
     assert_equal(len(anova), 4)
 
 

--- a/pyearth/test/basis/test_constant.py
+++ b/pyearth/test/basis/test_constant.py
@@ -11,7 +11,7 @@ from pyearth._basis import ConstantBasisFunction
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.bf = ConstantBasisFunction()
 
 

--- a/pyearth/test/basis/test_hinge.py
+++ b/pyearth/test/basis/test_hinge.py
@@ -12,7 +12,7 @@ from pyearth._basis import (HingeBasisFunction, SmoothedHingeBasisFunction,
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.parent = ConstantBasisFunction()
         self.bf = HingeBasisFunction(self.parent, 1.0, 10, 1, False)
 

--- a/pyearth/test/basis/test_linear.py
+++ b/pyearth/test/basis/test_linear.py
@@ -11,7 +11,7 @@ from pyearth._basis import LinearBasisFunction, ConstantBasisFunction
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.parent = ConstantBasisFunction()
         self.bf = LinearBasisFunction(self.parent, 1)
 

--- a/pyearth/test/basis/test_missingness.py
+++ b/pyearth/test/basis/test_missingness.py
@@ -12,7 +12,7 @@ from pyearth._basis import (
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.parent = ConstantBasisFunction()
         self.bf = MissingnessBasisFunction(self.parent, 1, True)
         self.child = HingeBasisFunction(self.bf, 1.0, 10, 1, False)

--- a/pyearth/test/basis/test_smoothed_hinge.py
+++ b/pyearth/test/basis/test_smoothed_hinge.py
@@ -11,7 +11,7 @@ from pyearth._basis import SmoothedHingeBasisFunction, ConstantBasisFunction
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.parent = ConstantBasisFunction()
         self.bf1 = SmoothedHingeBasisFunction(self.parent,
                                               1.0, 0.0, 3.0, 10, 1,
@@ -128,8 +128,8 @@ def test_apply_deriv():
     cp1 = numpy.ones(m)
     cp1[cnt.X[:, 1] <= 0.0] = 0.0
     cp1[(cnt.X[:, 1] > 0.0) & (cnt.X[:, 1] < 3.0)] = (
-        2.0 * pplus * ((cnt.X[(cnt.X[:, 1] > 0.0) &
-                              (cnt.X[:, 1] < 3.0), 1] - 0.0)) +
+        2.0 * pplus * (cnt.X[(cnt.X[:, 1] > 0.0) &
+                              (cnt.X[:, 1] < 3.0), 1] - 0.0) +
         3.0 * rplus * ((cnt.X[(cnt.X[:, 1] > 0.0) &
                               (cnt.X[:, 1] < 3.0), 1] - 0.0)**2)
     )
@@ -138,8 +138,8 @@ def test_apply_deriv():
     cp2[cnt.X[:, 1] >= 3.0] = 0.0
     cp2[cnt.X[:, 1] <= 0.0] = -1.0
     cp2[(cnt.X[:, 1] > 0.0) & (cnt.X[:, 1] < 3.0)] = (
-        2.0 * pminus * ((cnt.X[(cnt.X[:, 1] > 0.0) &
-                               (cnt.X[:, 1] < 3.0), 1] - 3.0)) +
+        2.0 * pminus * (cnt.X[(cnt.X[:, 1] > 0.0) &
+                               (cnt.X[:, 1] < 3.0), 1] - 3.0) +
         3.0 * rminus * ((cnt.X[(cnt.X[:, 1] > 0.0) &
                                (cnt.X[:, 1] < 3.0), 1] - 3.0)**2))
     cnt.bf1.apply_deriv(cnt.X, missing, b1, j1, 1)

--- a/pyearth/test/test_earth.py
+++ b/pyearth/test/test_earth.py
@@ -165,12 +165,12 @@ def test_missing_data():
     if regenerate_target_files:
         with open(filename, 'w') as fl:
             fl.write(res)
-    with open(filename, 'r') as fl:
+    with open(filename) as fl:
         prev = fl.read()
     try:
         assert_true(abs(float(res) - float(prev)) < .03)
     except AssertionError:
-        print('Got %f, %f' % (float(res), float(prev)))
+        print(('Got {:f}, {:f}'.format(float(res), float(prev))))
         raise
 
 def test_fit():
@@ -183,7 +183,7 @@ def test_fit():
     if regenerate_target_files:
         with open(filename, 'w') as fl:
             fl.write(res)
-    with open(filename, 'r') as fl:
+    with open(filename) as fl:
         prev = fl.read()
     assert_true(abs(float(res) - float(prev)) < .05)
 
@@ -198,7 +198,7 @@ def test_smooth():
     if regenerate_target_files:
         with open(filename, 'w') as fl:
             fl.write(res)
-    with open(filename, 'r') as fl:
+    with open(filename) as fl:
         prev = fl.read()
     assert_true(abs(float(res) - float(prev)) < .05)
 
@@ -212,7 +212,7 @@ def test_linvars():
     if regenerate_target_files:
         with open(filename, 'w') as fl:
             fl.write(res)
-    with open(filename, 'r') as fl:
+    with open(filename) as fl:
         prev = fl.read()
 
     assert_equal(res, prev)
@@ -230,7 +230,7 @@ def test_linvars_coefs():
                   check_every=1,
                   thresh=0,
                   minspan=1,
-                  endspan=1).fit(X, y, linvars=range(nb_vars))
+                  endspan=1).fit(X, y, linvars=list(range(nb_vars)))
     earth_bias = earth.coef_[0, 0]
     earth_coefs = sorted(earth.coef_[1:])
 
@@ -259,7 +259,7 @@ def test_pathological_cases():
                           'endspan': 1,
                           'check_every': 1,
                           'sample_weight': 'issue_50_weight.csv'}}
-    for case, settings in cases.iteritems():
+    for case, settings in list(cases.items()):
         data = pandas.read_csv(os.path.join(directory, case + '.csv'))
         y = data['y']
         del data['y']
@@ -272,7 +272,7 @@ def test_pathological_cases():
             sample_weight = None
         model = Earth(**settings)
         model.fit(X, y, sample_weight=sample_weight)
-        with open(os.path.join(directory, case + '.txt'), 'r') as infile:
+        with open(os.path.join(directory, case + '.txt')) as infile:
             correct = infile.read()
         assert_equal(model.summary(), correct)
 
@@ -524,7 +524,7 @@ def test_feature_importance():
     earth.fit(X, y)
     assert type(earth.feature_importances_) == dict
     assert set(earth.feature_importances_.keys()) == set(criteria)
-    for crit, val in earth .feature_importances_.items():
+    for crit, val in list(earth .feature_importances_.items()):
         assert len(val) == X.shape[1]
 
     assert_raises(

--- a/pyearth/test/test_export.py
+++ b/pyearth/test/test_export.py
@@ -49,7 +49,7 @@ def test_export_python_string():
     for smooth in (True, False):
         model = Earth(penalty=1, smooth=smooth, max_degree=2).fit(X, y)
         export_model = export_python_string(model, 'my_test_model')
-        six.exec_(export_model, globals())
+        exec(export_model, globals())
         for exp_pred, model_pred in zip(model.predict(X), my_test_model(X)):
             assert_almost_equal(exp_pred, model_pred)
 

--- a/pyearth/test/test_forward.py
+++ b/pyearth/test/test_forward.py
@@ -47,6 +47,6 @@ def test_run():
                             'forward_regress.txt')
 #     with open(filename, 'w') as fl:
 #         fl.write(res)
-    with open(filename, 'r') as fl:
+    with open(filename) as fl:
         prev = fl.read()
     assert_equal(res, prev)

--- a/pyearth/test/test_pruning.py
+++ b/pyearth/test/test_pruning.py
@@ -1,6 +1,4 @@
-
-
-class Test(object):
+class Test:
 
     def __init__(self):
         pass

--- a/pyearth/test/test_util.py
+++ b/pyearth/test/test_util.py
@@ -1,6 +1,4 @@
-
-
-class TestUtil(object):
+class TestUtil:
 
     def __init__(self):
         pass

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.18
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -276,7 +275,6 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 
 """
 
-from __future__ import print_function
 try:
     import configparser
 except ImportError:
@@ -340,7 +338,7 @@ def get_config_from_root(root):
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
     parser = configparser.ConfigParser()
-    with open(setup_cfg, "r") as f:
+    with open(setup_cfg) as f:
         parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
@@ -395,7 +393,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
                                  stderr=(subprocess.PIPE if hide_stderr
                                          else None))
             break
-        except EnvironmentError:
+        except OSError:
             e = sys.exc_info()[1]
             if e.errno == errno.ENOENT:
                 continue
@@ -405,7 +403,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print("unable to find command, tried {}".format(commands))
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
@@ -418,7 +416,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
     return stdout, p.returncode
 
 
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY['git'] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -950,7 +948,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        f = open(versionfile_abs, "r")
+        f = open(versionfile_abs)
         for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
@@ -965,7 +963,7 @@ def git_get_keywords(versionfile_abs):
                 if mo:
                     keywords["date"] = mo.group(1)
         f.close()
-    except EnvironmentError:
+    except OSError:
         pass
     return keywords
 
@@ -989,11 +987,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         if verbose:
             print("keywords are unexpanded, not using")
         raise NotThisMethod("unexpanded keywords, not a git-archive tarball")
-    refs = set([r.strip() for r in refnames.strip("()").split(",")])
+    refs = {r.strip() for r in refnames.strip("()").split(",")}
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = {r[len(TAG):] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -1002,7 +1000,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = {r for r in refs if re.search(r'\d', r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -1139,13 +1137,13 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
     files.append(versioneer_file)
     present = False
     try:
-        f = open(".gitattributes", "r")
+        f = open(".gitattributes")
         for line in f.readlines():
             if line.strip().startswith(versionfile_source):
                 if "export-subst" in line.strip().split()[1:]:
                     present = True
         f.close()
-    except EnvironmentError:
+    except OSError:
         pass
     if not present:
         f = open(".gitattributes", "a+")
@@ -1203,7 +1201,7 @@ def versions_from_file(filename):
     try:
         with open(filename) as f:
             contents = f.read()
-    except EnvironmentError:
+    except OSError:
         raise NotThisMethod("unable to read _version.py")
     mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON",
                    contents, re.M | re.S)
@@ -1223,7 +1221,7 @@ def write_to_version_file(filename, versions):
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
-    print("set %s to '%s'" % (filename, versions["version"]))
+    print("set {} to '{}'".format(filename, versions["version"]))
 
 
 def plus_or_dot(pieces):
@@ -1442,7 +1440,7 @@ def get_versions(verbose=False):
     try:
         ver = versions_from_file(versionfile_abs)
         if verbose:
-            print("got version from file %s %s" % (versionfile_abs, ver))
+            print("got version from file {} {}".format(versionfile_abs, ver))
         return ver
     except NotThisMethod:
         pass
@@ -1705,8 +1703,7 @@ def do_setup():
     root = get_root()
     try:
         cfg = get_config_from_root(root)
-    except (EnvironmentError, configparser.NoSectionError,
-            configparser.NoOptionError) as e:
+    except (OSError, configparser.NoSectionError, configparser.NoOptionError) as e:
         if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
             print("Adding sample versioneer config to setup.cfg",
                   file=sys.stderr)
@@ -1729,9 +1726,9 @@ def do_setup():
                        "__init__.py")
     if os.path.exists(ipy):
         try:
-            with open(ipy, "r") as f:
+            with open(ipy) as f:
                 old = f.read()
-        except EnvironmentError:
+        except OSError:
             old = ""
         if INIT_PY_SNIPPET not in old:
             print(" appending to %s" % ipy)
@@ -1750,12 +1747,12 @@ def do_setup():
     manifest_in = os.path.join(root, "MANIFEST.in")
     simple_includes = set()
     try:
-        with open(manifest_in, "r") as f:
+        with open(manifest_in) as f:
             for line in f:
                 if line.startswith("include "):
                     for include in line.split()[1:]:
                         simple_includes.add(include)
-    except EnvironmentError:
+    except OSError:
         pass
     # That doesn't cover everything MANIFEST.in can do
     # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
@@ -1787,7 +1784,7 @@ def scan_setup_py():
     found = set()
     setters = False
     errors = 0
-    with open("setup.py", "r") as f:
+    with open("setup.py") as f:
         for line in f.readlines():
             if "import versioneer" in line:
                 found.add("import")


### PR DESCRIPTION
## Summary
- modernize all Python sources with `pyupgrade` and `2to3`
- drop legacy basestring checks
- update versioneer setup and docs to Python 3 syntax

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_686775a0aa308331a061b4c26d26693e