### PR TITLE
Fix lapack header setup

### DIFF
--- a/gemini.md
+++ b/gemini.md
@@ -53,3 +53,4 @@ This phase explores potential new features to enhance the library's capabilities
 | **Improved Categorical Feature Handling** | More seamless and efficient handling of categorical features, potentially through integration with `sklearn.preprocessing` or custom encoding strategies optimized for MARS. |
 | **Interaction Term Export** | A utility function to export the learned interaction terms as features that can be used in other downstream models (e.g., linear models, GBDTs). |
 | **Gemini CLI Action** | A GitHub Action that uses the Gemini CLI to analyze model results, suggest improvements, or automate parts of the development workflow. |
+- **2025-06-30:** Attempted to build `_qr.pyx` with SciPy 1.16. Updated `_types.pxd` for NumPy 2.x and cleaned a debug print in `_qr.pyx`.

--- a/pyearth/_qr.pyx
+++ b/pyearth/_qr.pyx
@@ -4,9 +4,11 @@
 # cython: wraparound = False
 # cython: profile = False
 import numpy as np
+cimport numpy as cnp
 from scipy.linalg.cython_lapack cimport dlarfg, dlarft, dlarfb
 from scipy.linalg.cython_blas cimport dcopy
 from libc.math cimport abs
+from pyearth._types cimport FLOAT_t, BOOL_t
 from _types import BOOL, FLOAT
 
 cdef class UpdatingQT:
@@ -198,7 +200,7 @@ cdef class Householder:
         cdef int ldc = C.strides[1] // C.itemsize
         cdef FLOAT_t * work = <FLOAT_t *> &(self.work[0,0])
         cdef int ldwork = self.m
-        print C.shape
+        # Debug statement removed for Python 3 compatibility
         dlarfb(&side, &trans, &direct, &storev, &M, &N, &K, 
                V, &ldv, T, &ldt, C_arg, &ldc, work, &ldwork)
         

--- a/pyearth/_types.pxd
+++ b/pyearth/_types.pxd
@@ -1,5 +1,5 @@
 cimport numpy as cnp
 ctypedef cnp.float64_t FLOAT_t
-ctypedef cnp.int_t INT_t
+ctypedef cnp.int64_t INT_t
 ctypedef cnp.intp_t INDEX_t
 ctypedef cnp.uint8_t BOOL_t


### PR DESCRIPTION
## Summary
- fix `_qr.pyx` import to use pyearth types and remove stray debug statement
- update numpy type usage in `_types.pxd`
- log build attempt in `gemini.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_686770cbf86083319a69ed6a6f409cdb