### PR TITLE
Update dependencies for SciPy 1.10

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,22 +10,22 @@ requirements:
     - python
     - setuptools
     - cython
-    - numpy
-    - scikit-learn
+    - numpy >=1.19.5
+    - scikit-learn >=1.3
     - nose
     - six
   run:
     - python
-    - numpy
-    - scipy
-    - scikit-learn
+    - numpy >=1.19.5
+    - scipy >=1.10
+    - scikit-learn >=1.3
     - six
 
 test:
   requires:
-    - numpy
-    - scipy
-    - scikit-learn
+    - numpy >=1.19.5
+    - scipy >=1.10
+    - scikit-learn >=1.3
     - nose
   imports:
     - pyearth

--- a/setup.py
+++ b/setup.py
@@ -118,25 +118,23 @@ def setup_package():
                         'Operating System :: Unix',
                         'Programming Language :: Cython',
                         'Programming Language :: Python',
-                        'Programming Language :: Python :: 2',
-                        'Programming Language :: Python :: 2.6',
-                        'Programming Language :: Python :: 2.7',
                         'Programming Language :: Python :: 3',
-                        'Programming Language :: Python :: 3.4',
-                        'Programming Language :: Python :: 3.5',
-                        'Programming Language :: Python :: 3.6',
+                        'Programming Language :: Python :: 3.8',
+                        'Programming Language :: Python :: 3.9',
+                        'Programming Language :: Python :: 3.10',
+                        'Programming Language :: Python :: 3.11',
                         'Topic :: Scientific/Engineering',
                         'Topic :: Software Development'],
         'install_requires': [
-            'scipy >= 0.16',
-            'scikit-learn >= 0.16',
+            'scipy >= 1.10',
+            'scikit-learn >= 1.3',
             'six'
             ],
         'extras_require': {'docs': ['sphinx_gallery'],
                            'dev': ['cython'],
                            'export': ['sympy'],
                            'all_tests': ['pandas', 'statsmodels', 'patsy', 'sympy']},
-        'setup_requires': ['numpy'],
+        'setup_requires': ['numpy>=1.19.5'],
         'include_package_data': True
     }
 


### PR DESCRIPTION
## Summary
- set minimum SciPy to 1.10 and update scikit-learn/numpy versions
- drop Python 2/3.6 classifiers and list modern Python versions
- keep conda recipe in sync with new requirements

## Testing
- `make test` *(fails: cython: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686770c3b9cc8331a62059a5fadf4fd0