### PR TITLE
Update SciPy requirement in conda recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,10 +14,11 @@ requirements:
     - scikit-learn
     - nose
     - six
+    - scipy >=1.6
   run:
     - python
     - numpy
-    - scipy
+    - scipy >=1.6
     - scikit-learn
     - six
 

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ def setup_package():
                         'Topic :: Scientific/Engineering',
                         'Topic :: Software Development'],
         'install_requires': [
-            'scipy >= 0.16',
+            'scipy >= 1.6',
             'scikit-learn >= 0.16',
             'six'
             ],


### PR DESCRIPTION
## Summary
- specify modern SciPy in conda recipe
- keep setup.py dependency in sync

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_686770b5c8088331b4d6e557b94dcd73