### PR TITLE
Update SciPy requirements and drop Python 2 classifiers

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   run:
     - python
     - numpy
-    - scipy
+    - scipy >=1.7
     - scikit-learn
     - six
 

--- a/setup.py
+++ b/setup.py
@@ -118,9 +118,6 @@ def setup_package():
                         'Operating System :: Unix',
                         'Programming Language :: Cython',
                         'Programming Language :: Python',
-                        'Programming Language :: Python :: 2',
-                        'Programming Language :: Python :: 2.6',
-                        'Programming Language :: Python :: 2.7',
                         'Programming Language :: Python :: 3',
                         'Programming Language :: Python :: 3.4',
                         'Programming Language :: Python :: 3.5',
@@ -128,7 +125,7 @@ def setup_package():
                         'Topic :: Scientific/Engineering',
                         'Topic :: Software Development'],
         'install_requires': [
-            'scipy >= 0.16',
+            'scipy >= 1.7',
             'scikit-learn >= 0.16',
             'six'
             ],


### PR DESCRIPTION
## Summary
- require `scipy>=1.7` in `setup.py`
- remove Python 2 classifiers
- update conda recipe runtime to require SciPy 1.7+

## Testing
- `python -m pip install -e .` *(fails: FileNotFoundError during build)*

------
https://chatgpt.com/codex/tasks/task_e_686770bd0c94833192c381a877236135