### PR TITLE
Fix _qr cython build with modern SciPy

### DIFF
--- a/pyearth/_qr.pxd
+++ b/pyearth/_qr.pxd
@@ -1,5 +1,5 @@
 from cython cimport view
-from _types cimport FLOAT_t, INT_t, INDEX_t, BOOL_t
+from ._types cimport FLOAT_t, INT_t, INDEX_t, BOOL_t
 
 cdef class UpdatingQT:
     cdef readonly int m

--- a/pyearth/_qr.pyx
+++ b/pyearth/_qr.pyx
@@ -7,7 +7,7 @@ import numpy as np
 from scipy.linalg.cython_lapack cimport dlarfg, dlarft, dlarfb
 from scipy.linalg.cython_blas cimport dcopy
 from libc.math cimport abs
-from _types import BOOL, FLOAT
+from ._types import BOOL, FLOAT
 
 cdef class UpdatingQT:
     def __init__(UpdatingQT self, int m, int max_n, Householder householder, 
@@ -198,8 +198,7 @@ cdef class Householder:
         cdef int ldc = C.strides[1] // C.itemsize
         cdef FLOAT_t * work = <FLOAT_t *> &(self.work[0,0])
         cdef int ldwork = self.m
-        print C.shape
-        dlarfb(&side, &trans, &direct, &storev, &M, &N, &K, 
+        dlarfb(&side, &trans, &direct, &storev, &M, &N, &K,
                V, &ldv, T, &ldt, C_arg, &ldc, work, &ldwork)
         
     cpdef void left_apply_transpose(Householder self, FLOAT_t[::1, :] C):
@@ -259,6 +258,6 @@ cdef class Householder:
         cdef FLOAT_t * work = <FLOAT_t *> &(self.work[0,0])
         cdef int ldwork = self.m
         
-        dlarfb(&side, &trans, &direct, &storev, &M, &N, &K, 
+        dlarfb(&side, &trans, &direct, &storev, &M, &N, &K,
                V, &ldv, T, &ldt, C_arg, &ldc, work, &ldwork)
-#         
+

--- a/pyearth/_types.pxd
+++ b/pyearth/_types.pxd
@@ -1,5 +1,5 @@
 cimport numpy as cnp
 ctypedef cnp.float64_t FLOAT_t
-ctypedef cnp.int_t INT_t
+ctypedef cnp.int64_t INT_t
 ctypedef cnp.intp_t INDEX_t
 ctypedef cnp.uint8_t BOOL_t

--- a/pyearth/_types.pyx
+++ b/pyearth/_types.pyx
@@ -1,5 +1,5 @@
 import numpy as np
 FLOAT = np.float64
-INT = np.int
+INT = np.int64
 INDEX = np.intp
 BOOL = np.uint8


### PR DESCRIPTION
## Summary
- update imports in `_qr` to use package-relative paths
- drop stray debug print and end-of-file comment
- use `int64_t` for INT_t and `np.int64` in `pyearth._types`

## Testing
- `python build_qr.py build_ext --inplace`

------
https://chatgpt.com/codex/tasks/task_e_686770b4980483318880ff310d8b3139