### PR TITLE
Switch tests to pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 CYTHON ?= cython
-NOSETESTS ?= nosetests
+PYTEST ?= pytest
 CYTHONSRC=$(wildcard pyearth/*.pyx)
 CSRC=$(CYTHONSRC:.pyx=.c)
 
@@ -18,13 +18,13 @@ clean:
 	$(CYTHON) $<
 
 test: inplace
-	$(NOSETESTS) -s pyearth
+        $(PYTEST)
 
 test-coverage: inplace
-	$(NOSETESTS) -s --with-coverage --cover-html --cover-html-dir=coverage --cover-package=pyearth pyearth
+        $(PYTEST) --cov=pyearth --cov-report=html
 
 verbose-test: inplace
-	$(NOSETESTS) -sv pyearth
+        $(PYTEST) -sv
 
 conda:
 	conda-build conda-recipe

--- a/pyearth/test/basis/__init__.py
+++ b/pyearth/test/basis/__init__.py
@@ -1,6 +1,6 @@
 import pickle
 import os
-from nose.tools import assert_true, assert_false, assert_equal
+import pytest
 
 import numpy
 

--- a/pyearth/test/basis/test_basis.py
+++ b/pyearth/test/basis/test_basis.py
@@ -1,7 +1,7 @@
 import pickle
 import numpy
 
-from nose.tools import assert_equal, assert_true
+import pytest
 
 from .base import BaseContainer
 from pyearth._basis import (HingeBasisFunction, SmoothedHingeBasisFunction,
@@ -30,12 +30,12 @@ class Container(BaseContainer):
 def test_anova_decomp():
     cnt = Container()
     anova = cnt.basis.anova_decomp()
-    assert_equal(set(anova[frozenset([1])]), set([cnt.bf1]))
-    assert_equal(set(anova[frozenset([2])]), set([cnt.bf2, cnt.bf4,
-                                                  cnt.bf5]))
-    assert_equal(set(anova[frozenset([2, 3])]), set([cnt.bf3]))
-    assert_equal(set(anova[frozenset()]), set([cnt.parent]))
-    assert_equal(len(anova), 4)
+    assert set(anova[frozenset([1])]) == set([cnt.bf1])
+    assert set(anova[frozenset([2])]) == set([cnt.bf2, cnt.bf4,
+                                              cnt.bf5])
+    assert set(anova[frozenset([2, 3])]) == set([cnt.bf3])
+    assert set(anova[frozenset()]) == set([cnt.parent])
+    assert len(anova) == 4
 
 
 def test_smooth_knots():
@@ -43,11 +43,11 @@ def test_smooth_knots():
     mins = [0.0, -1.0, 0.1, 0.2]
     maxes = [2.5, 3.5, 3.0, 2.0]
     knots = cnt.basis.smooth_knots(mins, maxes)
-    assert_equal(knots[cnt.bf1], (0.0, 2.25))
-    assert_equal(knots[cnt.bf2], (0.55, 1.25))
-    assert_equal(knots[cnt.bf3], (0.6,  1.5))
-    assert_true(cnt.bf4 not in knots)
-    assert_equal(knots[cnt.bf5], (1.25, 2.25))
+    assert knots[cnt.bf1] == (0.0, 2.25)
+    assert knots[cnt.bf2] == (0.55, 1.25)
+    assert knots[cnt.bf3] == (0.6,  1.5)
+    assert cnt.bf4 not in knots
+    assert knots[cnt.bf5] == (1.25, 2.25)
 
 
 def test_smooth():
@@ -56,26 +56,26 @@ def test_smooth():
     smooth_basis = cnt.basis.smooth(X)
     for bf, smooth_bf in zip(cnt.basis, smooth_basis):
         if type(bf) is HingeBasisFunction:
-            assert_true(type(smooth_bf) is SmoothedHingeBasisFunction)
+            assert type(smooth_bf) is SmoothedHingeBasisFunction
         elif type(bf) is ConstantBasisFunction:
-            assert_true(type(smooth_bf) is ConstantBasisFunction)
+            assert type(smooth_bf) is ConstantBasisFunction
         elif type(bf) is LinearBasisFunction:
-            assert_true(type(smooth_bf) is LinearBasisFunction)
+            assert type(smooth_bf) is LinearBasisFunction
         else:
             raise AssertionError('Basis function is of an unexpected type.')
-        assert_true(type(smooth_bf) in {SmoothedHingeBasisFunction,
-                                        ConstantBasisFunction,
-                                        LinearBasisFunction})
+        assert type(smooth_bf) in {SmoothedHingeBasisFunction,
+                                   ConstantBasisFunction,
+                                   LinearBasisFunction}
         if bf.has_knot():
-            assert_equal(bf.get_knot(), smooth_bf.get_knot())
+            assert bf.get_knot() == smooth_bf.get_knot()
 
 
 def test_add():
     cnt = Container()
-    assert_equal(len(cnt.basis), 6)
+    assert len(cnt.basis) == 6
 
 
 def test_pickle_compat():
     cnt = Container()
     basis_copy = pickle.loads(pickle.dumps(cnt.basis))
-    assert_true(cnt.basis == basis_copy)
+    assert cnt.basis == basis_copy

--- a/pyearth/test/basis/test_constant.py
+++ b/pyearth/test/basis/test_constant.py
@@ -1,7 +1,7 @@
 import pickle
 import numpy
 
-from nose.tools import assert_true, assert_false
+import pytest
 
 from .base import BaseContainer
 from pyearth._types import BOOL
@@ -20,9 +20,9 @@ def test_apply():
     m, _ = cnt.X.shape
     missing = numpy.zeros_like(cnt.X, dtype=BOOL)
     B = numpy.empty(shape=(m, 10))
-    assert_false(numpy.all(B[:, 0] == 1))
+    assert not numpy.all(B[:, 0] == 1)
     cnt.bf.apply(cnt.X, missing, B[:, 0])
-    assert_true(numpy.all(B[:, 0] == 1))
+    assert numpy.all(B[:, 0] == 1)
 
 
 def test_deriv():
@@ -32,17 +32,17 @@ def test_deriv():
     b = numpy.empty(shape=m)
     j = numpy.empty(shape=m)
     cnt.bf.apply_deriv(cnt.X, missing, b, j, 1)
-    assert_true(numpy.all(b == 1))
-    assert_true(numpy.all(j == 0))
+    assert numpy.all(b == 1)
+    assert numpy.all(j == 0)
 
 
 def test_pickle_compatibility():
     cnt = Container()
     bf_copy = pickle.loads(pickle.dumps(cnt.bf))
-    assert_true(cnt.bf == bf_copy)
+    assert cnt.bf == bf_copy
 
 
 def test_smoothed_version():
     cnt = Container()
     smoothed = cnt.bf._smoothed_version(None, {}, {})
-    assert_true(type(smoothed) is ConstantBasisFunction)
+    assert type(smoothed) is ConstantBasisFunction

--- a/pyearth/test/basis/test_hinge.py
+++ b/pyearth/test/basis/test_hinge.py
@@ -1,7 +1,7 @@
 import pickle
 import numpy
 
-from nose.tools import assert_equal, assert_true
+import pytest
 
 from .base import BaseContainer
 from pyearth._types import BOOL
@@ -54,13 +54,13 @@ def test_apply_deriv():
 
 def test_degree():
     cnt = Container()
-    assert_equal(cnt.bf.degree(), 1)
+    assert cnt.bf.degree() == 1
 
 
 def test_pickle_compatibility():
     cnt = Container()
     bf_copy = pickle.loads(pickle.dumps(cnt.bf))
-    assert_true(cnt.bf == bf_copy)
+    assert cnt.bf == bf_copy
 
 
 def test_smoothed_version():
@@ -70,9 +70,9 @@ def test_smoothed_version():
     smoothed = cnt.bf._smoothed_version(cnt.parent, knot_dict,
                                         translation)
 
-    assert_true(type(smoothed) is SmoothedHingeBasisFunction)
-    assert_true(translation[cnt.parent] is smoothed.get_parent())
-    assert_equal(smoothed.get_knot_minus(), 0.5)
-    assert_equal(smoothed.get_knot_plus(), 1.5)
-    assert_equal(smoothed.get_knot(), cnt.bf.get_knot())
-    assert_equal(smoothed.get_variable(), cnt.bf.get_variable())
+    assert type(smoothed) is SmoothedHingeBasisFunction
+    assert translation[cnt.parent] is smoothed.get_parent()
+    assert smoothed.get_knot_minus() == 0.5
+    assert smoothed.get_knot_plus() == 1.5
+    assert smoothed.get_knot() == cnt.bf.get_knot()
+    assert smoothed.get_variable() == cnt.bf.get_variable()

--- a/pyearth/test/basis/test_linear.py
+++ b/pyearth/test/basis/test_linear.py
@@ -1,7 +1,7 @@
 import pickle
 import numpy
 
-from nose.tools import assert_equal, assert_true
+import pytest
 
 from .base import BaseContainer
 from pyearth._types import BOOL
@@ -22,7 +22,7 @@ def test_apply():
     missing = numpy.zeros_like(cnt.X, dtype=BOOL)
     B = numpy.ones(shape=(m, 10))
     cnt.bf.apply(cnt.X, missing, B[:, 0])
-    assert_true(numpy.all(B[:, 0] == cnt.X[:, 1]))
+    assert numpy.all(B[:, 0] == cnt.X[:, 1])
 
 
 def test_apply_deriv():
@@ -38,18 +38,18 @@ def test_apply_deriv():
 
 def test_degree():
     cnt = Container()
-    assert_equal(cnt.bf.degree(), 1)
+    assert cnt.bf.degree() == 1
 
 
 def test_pickle_compatibility():
     cnt = Container()
     bf_copy = pickle.loads(pickle.dumps(cnt.bf))
-    assert_true(cnt.bf == bf_copy)
+    assert cnt.bf == bf_copy
 
 
 def test_smoothed_version():
     cnt = Container()
     translation = {cnt.parent: cnt.parent._smoothed_version(None, {}, {})}
     smoothed = cnt.bf._smoothed_version(cnt.parent, {}, translation)
-    assert_true(isinstance(smoothed, LinearBasisFunction))
-    assert_equal(smoothed.get_variable(), cnt.bf.get_variable())
+    assert isinstance(smoothed, LinearBasisFunction)
+    assert smoothed.get_variable() == cnt.bf.get_variable()

--- a/pyearth/test/basis/test_missingness.py
+++ b/pyearth/test/basis/test_missingness.py
@@ -1,7 +1,7 @@
 import pickle
 import numpy
 
-from nose.tools import assert_equal, assert_true
+import pytest
 
 from .base import BaseContainer
 from pyearth._types import BOOL
@@ -65,13 +65,13 @@ def test_apply():
 
 def test_degree():
     cnt = Container()
-    assert_equal(cnt.bf.degree(), 1)
+    assert cnt.bf.degree() == 1
 
 
 def test_pickle_compatibility():
     cnt = Container()
     bf_copy = pickle.loads(pickle.dumps(cnt.bf))
-    assert_true(cnt.bf == bf_copy)
+    assert cnt.bf == bf_copy
 
 #
 # def test_smoothed_version():

--- a/pyearth/test/basis/test_smoothed_hinge.py
+++ b/pyearth/test/basis/test_smoothed_hinge.py
@@ -1,7 +1,7 @@
 import pickle
 import numpy
 
-from nose.tools import assert_equal
+import pytest
 
 from .base import BaseContainer
 from pyearth._types import BOOL
@@ -36,20 +36,20 @@ def test_getters():
 def test_pickle_compatibility():
     cnt = Container()
     bf_copy = pickle.loads(pickle.dumps(cnt.bf1))
-    assert_equal(cnt.bf1, bf_copy)
+    assert cnt.bf1 == bf_copy
 
 
 def test_smoothed_version():
     cnt = Container()
     translation = {cnt.parent: cnt.parent._smoothed_version(None, {}, {})}
     smoothed = cnt.bf1._smoothed_version(cnt.parent, {}, translation)
-    assert_equal(cnt.bf1, smoothed)
+    assert cnt.bf1 == smoothed
 
 
 def test_degree():
     cnt = Container()
-    assert_equal(cnt.bf1.degree(), 1)
-    assert_equal(cnt.bf2.degree(), 1)
+    assert cnt.bf1.degree() == 1
+    assert cnt.bf2.degree() == 1
 
 
 def test_p_r():
@@ -58,10 +58,10 @@ def test_p_r():
     rplus = (2 * 1.0 - 3.0 - 0.0) / ((3.0 - 0.0)**3)
     pminus = (3 * 1.0 - 2 * 0.0 - 3.0) / ((0.0 - 3.0)**2)
     rminus = (0.0 + 3.0 - 2 * 1.0) / ((0.0 - 3.0)**3)
-    assert_equal(cnt.bf1.get_p(), pplus)
-    assert_equal(cnt.bf1.get_r(), rplus)
-    assert_equal(cnt.bf2.get_p(), pminus)
-    assert_equal(cnt.bf2.get_r(), rminus)
+    assert cnt.bf1.get_p() == pplus
+    assert cnt.bf1.get_r() == rplus
+    assert cnt.bf2.get_p() == pminus
+    assert cnt.bf2.get_r() == rminus
 
 
 def test_apply():

--- a/pyearth/test/test_earth.py
+++ b/pyearth/test/test_earth.py
@@ -11,8 +11,8 @@ from .testing_utils import (if_statsmodels, if_pandas, if_patsy,
                             assert_list_almost_equal,
                             if_sklearn_version_greater_than_or_equal_to,
                             if_platform_not_win_32)
-from nose.tools import (assert_equal, assert_true, assert_almost_equal,
-                        assert_list_equal, assert_raises, assert_not_equal)
+import pytest
+from numpy.testing import assert_almost_equal
 import numpy
 from scipy.sparse import csr_matrix
 from pyearth._types import BOOL
@@ -53,8 +53,8 @@ def test_check_estimator():
 
 
 def test_get_params():
-    assert_equal(
-        Earth().get_params(), {'penalty': None, 'min_search_points': None,
+    assert (
+        Earth().get_params() == {'penalty': None, 'min_search_points': None,
                                'endspan_alpha': None, 'check_every': None,
                                'max_terms': None, 'max_degree': None,
                                'minspan_alpha': None, 'thresh': None,
@@ -67,9 +67,9 @@ def test_get_params():
                                'allow_missing': False,
                                'feature_importance_type': None,
                                'verbose': False})
-    assert_equal(
+    assert (
         Earth(
-            max_degree=3).get_params(), {'penalty': None,
+            max_degree=3).get_params() == {'penalty': None,
                                          'min_search_points': None,
                                          'endspan_alpha': None,
                                          'check_every': None,
@@ -116,8 +116,8 @@ def test_sample_weight():
     model = Earth().fit(x[:, numpy.newaxis], y, sample_weight=sample_weight)
 
     # Check that the model fits better for the more heavily weighted group
-    assert_true(model.score(x[group], y[group]) < model.score(
-        x[numpy.logical_not(group)], y[numpy.logical_not(group)]))
+    assert model.score(x[group], y[group]) < model.score(
+        x[numpy.logical_not(group)], y[numpy.logical_not(group)])
 
     # Make sure that the score function gives the same answer as the trace
     pruning_trace = model.pruning_trace()
@@ -148,8 +148,8 @@ def test_output_weight():
     mse = ((model.predict(x) - y)**2).mean(axis=0)
     group1_mean = mse[group].mean()
     group2_mean = mse[numpy.logical_not(group)].mean()
-    assert_true(group1_mean > group2_mean or
-                round(abs(group1_mean - group2_mean), 7) == 0)
+    assert group1_mean > group2_mean or \
+        round(abs(group1_mean - group2_mean), 7) == 0
 
 
 def test_missing_data():
@@ -168,7 +168,7 @@ def test_missing_data():
     with open(filename, 'r') as fl:
         prev = fl.read()
     try:
-        assert_true(abs(float(res) - float(prev)) < .03)
+        assert abs(float(res) - float(prev)) < .03
     except AssertionError:
         print('Got %f, %f' % (float(res), float(prev)))
         raise
@@ -185,7 +185,7 @@ def test_fit():
             fl.write(res)
     with open(filename, 'r') as fl:
         prev = fl.read()
-    assert_true(abs(float(res) - float(prev)) < .05)
+    assert abs(float(res) - float(prev)) < .05
 
 
 def test_smooth():
@@ -200,7 +200,7 @@ def test_smooth():
             fl.write(res)
     with open(filename, 'r') as fl:
         prev = fl.read()
-    assert_true(abs(float(res) - float(prev)) < .05)
+    assert abs(float(res) - float(prev)) < .05
 
 
 def test_linvars():
@@ -215,7 +215,7 @@ def test_linvars():
     with open(filename, 'r') as fl:
         prev = fl.read()
 
-    assert_equal(res, prev)
+    assert res == prev
 
 
 def test_linvars_coefs():
@@ -274,7 +274,7 @@ def test_pathological_cases():
         model.fit(X, y, sample_weight=sample_weight)
         with open(os.path.join(directory, case + '.txt'), 'r') as infile:
             correct = infile.read()
-        assert_equal(model.summary(), correct)
+        assert model.summary() == correct
 
 
 @if_pandas
@@ -287,8 +287,7 @@ def test_pandas_compatibility():
 
     earth = Earth(**default_params)
     model = earth.fit(X_df, y_df)
-    assert_list_equal(
-        colnames, model.forward_trace()._getstate()['xlabels'])
+    assert colnames == model.forward_trace()._getstate()['xlabels']
 
 
 @if_patsy
@@ -306,38 +305,37 @@ def test_patsy_compatibility():
         data=X_df)
 
     model = Earth(**default_params).fit(X_df, y_df)
-    assert_list_equal(
-        colnames, model.forward_trace()._getstate()['xlabels'])
+    assert colnames == model.forward_trace()._getstate()['xlabels']
 
 
 def test_pickle_compatibility():
     earth = Earth(**default_params)
     model = earth.fit(X, y)
     model_copy = pickle.loads(pickle.dumps(model))
-    assert_true(model_copy == model)
+    assert model_copy == model
     assert_array_almost_equal(model.predict(X), model_copy.predict(X))
-    assert_true(model.basis_[0] is model.basis_[1]._get_root())
-    assert_true(model_copy.basis_[0] is model_copy.basis_[1]._get_root())
+    assert model.basis_[0] is model.basis_[1]._get_root()
+    assert model_copy.basis_[0] is model_copy.basis_[1]._get_root()
 
 
 def test_pickle_version_storage():
     earth = Earth(**default_params)
     model = earth.fit(X, y)
-    assert_equal(model._version, pyearth.__version__)
+    assert model._version == pyearth.__version__
     model._version = 'hello'
-    assert_equal(model._version,'hello')
+    assert model._version == 'hello'
     model_copy = pickle.loads(pickle.dumps(model))
-    assert_equal(model_copy._version, model._version)
+    assert model_copy._version == model._version
 
 
 def test_copy_compatibility():
     numpy.random.seed(0)
     model = Earth(**default_params).fit(X, y)
     model_copy = copy.copy(model)
-    assert_true(model_copy == model)
+    assert model_copy == model
     assert_array_almost_equal(model.predict(X), model_copy.predict(X))
-    assert_true(model.basis_[0] is model.basis_[1]._get_root())
-    assert_true(model_copy.basis_[0] is model_copy.basis_[1]._get_root())
+    assert model.basis_[0] is model.basis_[1]._get_root()
+    assert model_copy.basis_[0] is model_copy.basis_[1]._get_root()
 
 
 def test_exhaustive_search():
@@ -348,8 +346,8 @@ def test_exhaustive_search():
                   minspan=1,
                   endspan=1)
     model.fit(X, y)
-    assert_equal(model.basis_.plen(), model.coef_.shape[1])
-    assert_equal(model.transform(X).shape[1], len(model.basis_))
+    assert model.basis_.plen() == model.coef_.shape[1]
+    assert model.transform(X).shape[1] == len(model.basis_)
 
 
 def test_nb_terms():
@@ -357,9 +355,9 @@ def test_nb_terms():
     for max_terms in (1, 3, 12, 13):
         model = Earth(max_terms=max_terms)
         model.fit(X, y)
-        assert_true(len(model.basis_) <= max_terms + 2)
-        assert_true(len(model.coef_) <= len(model.basis_))
-        assert_true(len(model.coef_) >= 1)
+        assert len(model.basis_) <= max_terms + 2
+        assert len(model.coef_) <= len(model.basis_)
+        assert len(model.coef_) >= 1
         if max_terms == 1:
             assert_list_almost_equal_value(model.predict(X), y.mean())
 
@@ -375,43 +373,49 @@ def test_nb_degrees():
                       endspan=1)
         model.fit(X, y)
         for basis in model.basis_:
-            assert_true(basis.degree() >= 0)
-            assert_true(basis.degree() <= max_degree)
+            assert basis.degree() >= 0
+            assert basis.degree() <= max_degree
 
 
 def test_eq():
     model1 = Earth(**default_params)
     model2 = Earth(**default_params)
-    assert_equal(model1, model2)
-    assert_not_equal(model1, 5)
+    assert model1 == model2
+    assert model1 != 5
 
     params = {}
     params.update(default_params)
     params["penalty"] = 15
     model2 = Earth(**params)
-    assert_not_equal(model1, model2)
+    assert model1 != model2
 
     model3 = Earth(**default_params)
     model3.unknown_parameter = 5
-    assert_not_equal(model1, model3)
+    assert model1 != model3
 
 
 def test_sparse():
     X_sparse = csr_matrix(X)
 
     model = Earth(**default_params)
-    assert_raises(TypeError, model.fit, X_sparse, y)
+    with pytest.raises(TypeError):
+        model.fit(X_sparse, y)
 
     model = Earth(**default_params)
     model.fit(X, y)
-    assert_raises(TypeError, model.predict, X_sparse)
-    assert_raises(TypeError, model.predict_deriv, X_sparse)
-    assert_raises(TypeError, model.transform, X_sparse)
-    assert_raises(TypeError, model.score, X_sparse)
+    with pytest.raises(TypeError):
+        model.predict(X_sparse)
+    with pytest.raises(TypeError):
+        model.predict_deriv(X_sparse)
+    with pytest.raises(TypeError):
+        model.transform(X_sparse)
+    with pytest.raises(TypeError):
+        model.score(X_sparse)
 
     model = Earth(**default_params)
     sample_weight = csr_matrix([1.] * X.shape[0])
-    assert_raises(TypeError, model.fit, X, y, sample_weight)
+    with pytest.raises(TypeError):
+        model.fit(X, y, sample_weight)
 
 
 def test_shape():
@@ -419,53 +423,59 @@ def test_shape():
     model.fit(X, y)
 
     X_reduced = X[:, 0:5]
-    assert_raises(ValueError, model.predict, X_reduced)
-    assert_raises(ValueError, model.predict_deriv, X_reduced)
-    assert_raises(ValueError, model.transform, X_reduced)
-    assert_raises(ValueError, model.score, X_reduced)
+    with pytest.raises(ValueError):
+        model.predict(X_reduced)
+    with pytest.raises(ValueError):
+        model.predict_deriv(X_reduced)
+    with pytest.raises(ValueError):
+        model.transform(X_reduced)
+    with pytest.raises(ValueError):
+        model.score(X_reduced)
 
     model = Earth(**default_params)
     X_subsampled = X[0:10]
-    assert_raises(ValueError, model.fit, X_subsampled, y)
+    with pytest.raises(ValueError):
+        model.fit(X_subsampled, y)
 
     model = Earth(**default_params)
     y_subsampled = X[0:10]
-    assert_raises(ValueError, model.fit, X, y_subsampled)
+    with pytest.raises(ValueError):
+        model.fit(X, y_subsampled)
 
     model = Earth(**default_params)
     sample_weights = numpy.array([1.] * len(X))
     sample_weights_subsampled = sample_weights[0:10]
-    assert_raises(ValueError, model.fit, X, y, sample_weights_subsampled)
+    with pytest.raises(ValueError):
+        model.fit(X, y, sample_weights_subsampled)
 
 
 def test_deriv():
 
     model = Earth(**default_params)
     model.fit(X, y)
-    assert_equal(X.shape + (1,), model.predict_deriv(X).shape)
-    assert_equal((X.shape[0], 1, 1), model.predict_deriv(X, variables=0).shape)
-    assert_equal((X.shape[0], 1, 1), model.predict_deriv(
-        X, variables='x0').shape)
-    assert_equal((X.shape[0], 3, 1),
-                 model.predict_deriv(X, variables=[1, 5, 7]).shape)
-    assert_equal((X.shape[0], 0, 1),
-                 model.predict_deriv(X, variables=[]).shape)
+    assert model.predict_deriv(X).shape == X.shape + (1,)
+    assert model.predict_deriv(X, variables=0).shape == (X.shape[0], 1, 1)
+    assert model.predict_deriv(
+        X, variables='x0').shape == (X.shape[0], 1, 1)
+    assert model.predict_deriv(X, variables=[1, 5, 7]).shape == (
+        X.shape[0], 3, 1)
+    assert model.predict_deriv(X, variables=[]).shape == (
+        X.shape[0], 0, 1)
 
     res_deriv = model.predict_deriv(X, variables=['x2', 'x7', 'x0', 'x1'])
-    assert_equal((X.shape[0], 4, 1), res_deriv.shape)
+    assert res_deriv.shape == (X.shape[0], 4, 1)
 
     res_deriv = model.predict_deriv(X, variables=['x0'])
-    assert_equal((X.shape[0], 1, 1), res_deriv.shape)
+    assert res_deriv.shape == (X.shape[0], 1, 1)
 
-    assert_equal((X.shape[0], 1, 1),
-                 model.predict_deriv(X, variables=[0]).shape)
+    assert model.predict_deriv(X, variables=[0]).shape == (X.shape[0], 1, 1)
 
 
 def test_xlabels():
 
     model = Earth(**default_params)
-    assert_raises(ValueError, model.fit, X[
-                  :, 0:5], y, xlabels=['var1', 'var2'])
+    with pytest.raises(ValueError):
+        model.fit(X[:, 0:5], y, xlabels=['var1', 'var2'])
 
     model = Earth(**default_params)
     model.fit(X[:, 0:3], y, xlabels=['var1', 'var2', 'var3'])
@@ -486,15 +496,19 @@ def test_untrained():
     # raises the appropriate exception when using a not yet fitted
     # Earth object
     model = Earth(**default_params)
-    assert_raises(NotFittedError, model.predict, X)
-    assert_raises(NotFittedError, model.transform, X)
-    assert_raises(NotFittedError, model.predict_deriv, X)
-    assert_raises(NotFittedError, model.score, X)
+    with pytest.raises(NotFittedError):
+        model.predict(X)
+    with pytest.raises(NotFittedError):
+        model.transform(X)
+    with pytest.raises(NotFittedError):
+        model.predict_deriv(X)
+    with pytest.raises(NotFittedError):
+        model.score(X)
 
     # the following should be changed to raise NotFittedError
-    assert_equal(model.forward_trace(), None)
-    assert_equal(model.pruning_trace(), None)
-    assert_equal(model.summary(), "Untrained Earth Model")
+    assert model.forward_trace() is None
+    assert model.pruning_trace() is None
+    assert model.summary() == "Untrained Earth Model"
 
 
 def test_fast():
@@ -511,7 +525,7 @@ def test_fast():
                   **default_params)
     earth.fit(X, y)
     fast_summary = earth.summary()
-    assert_equal(normal_summary, fast_summary)
+    assert normal_summary == fast_summary
 
 
 def test_feature_importance():
@@ -527,16 +541,14 @@ def test_feature_importance():
     for crit, val in earth .feature_importances_.items():
         assert len(val) == X.shape[1]
 
-    assert_raises(
-            ValueError,
-            Earth(feature_importance_type='bad_name', **default_params).fit,
+    with pytest.raises(ValueError):
+        Earth(feature_importance_type='bad_name', **default_params).fit(
             X, y)
 
     earth = Earth(feature_importance_type=('rss',), **default_params)
     earth.fit(X, y)
     assert len(earth.feature_importances_) == X.shape[1]
 
-    assert_raises(
-            ValueError,
-            Earth(feature_importance_type='rss', enable_pruning=False, **default_params).fit,
+    with pytest.raises(ValueError):
+        Earth(feature_importance_type='rss', enable_pruning=False, **default_params).fit(
             X, y)

--- a/pyearth/test/test_export.py
+++ b/pyearth/test/test_export.py
@@ -2,7 +2,7 @@ from pyearth._basis import (Basis, ConstantBasisFunction, HingeBasisFunction,
                             LinearBasisFunction)
 from pyearth.export import export_python_function, export_python_string,\
     export_sympy
-from nose.tools import assert_almost_equal
+from numpy.testing import assert_almost_equal
 import numpy
 import six
 from pyearth import Earth

--- a/pyearth/test/test_forward.py
+++ b/pyearth/test/test_forward.py
@@ -7,7 +7,8 @@ Created on Feb 16, 2013
 import os
 import numpy
 
-from nose.tools import assert_equal
+
+import pytest
 
 from pyearth._forward import ForwardPasser
 from pyearth._basis import (Basis, ConstantBasisFunction,
@@ -49,4 +50,4 @@ def test_run():
 #         fl.write(res)
     with open(filename, 'r') as fl:
         prev = fl.read()
-    assert_equal(res, prev)
+    assert res == prev

--- a/pyearth/test/test_knot_search.py
+++ b/pyearth/test/test_knot_search.py
@@ -6,7 +6,7 @@ from pyearth._knot_search import (MultipleOutcomeDependentData,
                                   knot_search,
                                   SingleWeightDependentData,
                                   SingleOutcomeDependentData)
-from nose.tools import assert_equal
+import pytest
 import numpy as np
 from numpy.testing.utils import assert_almost_equal, assert_array_equal
 from scipy.linalg import qr
@@ -30,11 +30,11 @@ def test_outcome_dependent_data():
         if k >= 99:
             1 + 1
         data.update()
-        assert_equal(code, 0)
+        assert code == 0
         assert_almost_equal(
             np.dot(weight.Q_t[:k + 1, :], np.transpose(weight.Q_t[:k + 1, :])),
             np.eye(k + 1))
-    assert_equal(weight.update_from_array(b), -1)
+    assert weight.update_from_array(b) == -1
 #     data.update(1e-16)
 
     # Test downdating
@@ -53,11 +53,11 @@ def test_outcome_dependent_data():
     assert_almost_equal(np.abs(np.dot(weight.Q_t, Q)), np.eye(max_terms))
 
     # Test that reweighting works
-    assert_equal(data.k, max_terms)
+    assert data.k == max_terms
     w2 = np.random.normal(size=m) ** 2
     weight.reweight(w2, B, max_terms)
     data.synchronize()
-    assert_equal(data.k, max_terms)
+    assert data.k == max_terms
     w2B = B * w2[:, None]
     Q2, _ = qr(w2B, pivoting=False, mode='economic')
     assert_almost_equal(np.abs(np.dot(weight.Q_t, Q2)), np.eye(max_terms))
@@ -76,7 +76,7 @@ def test_knot_candidates():
     candidates, candidates_idx = predictor.knot_candidates(
         p, 5, 10, 0, 0, set())
     assert_array_equal(candidates, x[candidates_idx])
-    assert_equal(len(candidates), len(set(candidates)))
+    assert len(candidates) == len(set(candidates))
 #     print candidates, np.sum(x==0)
 #     print candidates_idx
 
@@ -182,15 +182,15 @@ def test_knot_search():
 
     # Test the test
     assert_almost_equal(best_knot, knot)
-    assert_equal(r, len(candidates))
-    assert_equal(m, B.shape[0])
-    assert_equal(q, B.shape[1])
-    assert_equal(len(outcomes), n_outcomes)
+    assert r == len(candidates)
+    assert m == B.shape[0]
+    assert q == B.shape[1]
+    assert len(outcomes) == n_outcomes
 
     # Run fast knot search and compare results to slow knot search
     fast_best_knot, fast_best_k, fast_best_e = knot_search(data, candidates,
                                                            p, q, m, r,
                                                            len(outcomes), 0)
     assert_almost_equal(fast_best_knot, best_knot)
-    assert_equal(candidates[fast_best_k], candidates[best_k])
+    assert candidates[fast_best_k] == candidates[best_k]
     assert_almost_equal(fast_best_e, best_e)

--- a/pyearth/test/test_pruning.py
+++ b/pyearth/test/test_pruning.py
@@ -9,5 +9,5 @@ class Test(object):
         pass
 
 if __name__ == '__main__':
-    import nose
-    nose.run(argv=[__file__, '-s', '-v'])
+    import pytest
+    pytest.main([__file__])

--- a/pyearth/test/test_util.py
+++ b/pyearth/test/test_util.py
@@ -9,5 +9,5 @@ class TestUtil(object):
         pass
 
 if __name__ == '__main__':
-    import nose
-    nose.run(argv=[__file__, '-s', '-v'])
+    import pytest
+    pytest.main([__file__])

--- a/pyearth/test/testing_utils.py
+++ b/pyearth/test/testing_utils.py
@@ -1,7 +1,7 @@
 import os
 from functools import wraps
-from nose import SkipTest
-from nose.tools import assert_almost_equal
+import pytest
+from numpy.testing import assert_almost_equal
 from distutils.version import LooseVersion
 import sys
 
@@ -13,8 +13,8 @@ def if_environ_has(var_name):
             if var_name in os.environ:
                 return func(*args, **kwargs)
             else:
-                raise SkipTest('Only run if %s environment variable is '
-                               'defined.' % var_name)
+                pytest.skip('Only run if %s environment variable is '
+                            'defined.' % var_name)
         return run_test
     return if_environ
 
@@ -22,7 +22,7 @@ def if_platform_not_win_32(func):
     @wraps(func)
     def run_test(*args, **kwargs):
         if sys.platform == 'win32':
-            raise SkipTest('Skip for 32 bit Windows platforms.')
+            pytest.skip('Skip for 32 bit Windows platforms.')
         else:
             return func(*args, **kwargs)
     return run_test
@@ -37,8 +37,8 @@ def if_sklearn_version_greater_than_or_equal_to(min_version):
         def run_test(*args, **kwargs):
             import sklearn
             if LooseVersion(sklearn.__version__) < LooseVersion(min_version):
-                raise SkipTest('sklearn version less than %s' %
-                               str(min_version))
+                pytest.skip('sklearn version less than %s' %
+                            str(min_version))
             else:
                 return func(*args, **kwargs)
         return run_test
@@ -53,7 +53,7 @@ def if_statsmodels(func):
         try:
             import statsmodels
         except ImportError:
-            raise SkipTest('statsmodels not available.')
+            pytest.skip('statsmodels not available.')
         else:
             return func(*args, **kwargs)
     return run_test
@@ -67,7 +67,7 @@ def if_pandas(func):
         try:
             import pandas
         except ImportError:
-            raise SkipTest('pandas not available.')
+            pytest.skip('pandas not available.')
         else:
             return func(*args, **kwargs)
     return run_test
@@ -80,7 +80,7 @@ def if_sympy(func):
         try:
             from sympy import Symbol, Add, Mul, Max, RealNumber, Piecewise, sympify, Pow, And, lambdify
         except ImportError:
-            raise SkipTest('sympy not available.')
+            pytest.skip('sympy not available.')
         else:
             return func(*args, **kwargs)
     return run_test
@@ -95,7 +95,7 @@ def if_patsy(func):
         try:
             import patsy
         except ImportError:
-            raise SkipTest('patsy not available.')
+            pytest.skip('patsy not available.')
         else:
             return func(*args, **kwargs)
     return run_test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = pyearth/test
+addopts = -ra


### PR DESCRIPTION
## Summary
- migrate nose assertions to pytest-style `assert` statements
- add a basic `pytest.ini`
- update the Makefile to use pytest instead of nosetests

## Testing
- `python setup.py build_ext --inplace` *(fails: longintrepr.h missing)*
- `pytest -q` *(fails: ModuleNotFoundError: pyearth._forward)*

------
https://chatgpt.com/codex/tasks/task_e_686714c41bbc833191fa32b14d7a9eda