### PR TITLE
Remove legacy basestring checks

### DIFF
--- a/pyearth/_pruning.c
+++ b/pyearth/_pruning.c
@@ -3174,7 +3174,7 @@ static int __pyx_pf_7pyearth_8_pruning_13PruningPasser___init__(struct __pyx_obj
  * 
  *         # feature importance
  *         feature_importance_criteria = kwargs.get("feature_importance_type", [])             # <<<<<<<<<<<<<<
- *         if isinstance(feature_importance_criteria, basestring):
+ *         if isinstance(feature_importance_criteria, str):
  *             feature_importance_criteria = [feature_importance_criteria]
  */
   __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 40, __pyx_L1_error)
@@ -3188,7 +3188,7 @@ static int __pyx_pf_7pyearth_8_pruning_13PruningPasser___init__(struct __pyx_obj
   /* "pyearth/_pruning.pyx":41
  *         # feature importance
  *         feature_importance_criteria = kwargs.get("feature_importance_type", [])
- *         if isinstance(feature_importance_criteria, basestring):             # <<<<<<<<<<<<<<
+ *         if isinstance(feature_importance_criteria, str):             # <<<<<<<<<<<<<<
  *             feature_importance_criteria = [feature_importance_criteria]
  *         self.feature_importance = dict()
  */
@@ -3198,7 +3198,7 @@ static int __pyx_pf_7pyearth_8_pruning_13PruningPasser___init__(struct __pyx_obj
 
     /* "pyearth/_pruning.pyx":42
  *         feature_importance_criteria = kwargs.get("feature_importance_type", [])
- *         if isinstance(feature_importance_criteria, basestring):
+ *         if isinstance(feature_importance_criteria, str):
  *             feature_importance_criteria = [feature_importance_criteria]             # <<<<<<<<<<<<<<
  *         self.feature_importance = dict()
  *         for criterion in feature_importance_criteria:
@@ -3214,14 +3214,14 @@ static int __pyx_pf_7pyearth_8_pruning_13PruningPasser___init__(struct __pyx_obj
     /* "pyearth/_pruning.pyx":41
  *         # feature importance
  *         feature_importance_criteria = kwargs.get("feature_importance_type", [])
- *         if isinstance(feature_importance_criteria, basestring):             # <<<<<<<<<<<<<<
+ *         if isinstance(feature_importance_criteria, str):             # <<<<<<<<<<<<<<
  *             feature_importance_criteria = [feature_importance_criteria]
  *         self.feature_importance = dict()
  */
   }
 
   /* "pyearth/_pruning.pyx":43
- *         if isinstance(feature_importance_criteria, basestring):
+ *         if isinstance(feature_importance_criteria, str):
  *             feature_importance_criteria = [feature_importance_criteria]
  *         self.feature_importance = dict()             # <<<<<<<<<<<<<<
  *         for criterion in feature_importance_criteria:

--- a/pyearth/_pruning.pyx
+++ b/pyearth/_pruning.pyx
@@ -38,7 +38,7 @@ cdef class PruningPasser:
 
         # feature importance
         feature_importance_criteria = kwargs.get("feature_importance_type", [])
-        if isinstance(feature_importance_criteria, basestring):
+        if isinstance(feature_importance_criteria, str):
             feature_importance_criteria = [feature_importance_criteria]
         self.feature_importance = dict()
         for criterion in feature_importance_criteria:

--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -589,11 +589,7 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
             self.xlabels_ = xlabels
         if self.feature_importance_type is not None:
             feature_importance_type = self.feature_importance_type
-            try:
-                is_str = isinstance(feature_importance_type, basestring)
-            except NameError:
-                is_str = isinstance(feature_importance_type, str)
-            if is_str:
+            if isinstance(feature_importance_type, str):
                 feature_importance_type = [feature_importance_type]
             for k in feature_importance_type:
                 if k not in FEAT_IMP_CRITERIA:


### PR DESCRIPTION
## Summary
- modernize feature importance validation
- clean up Python 2 compatibility branch in pruning code
- update generated pruning C file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*


------
https://chatgpt.com/codex/tasks/task_e_686608639d4c8331b2fb55f96b9cdebb