### PR TITLE
Clarify weighting in forward GCV calculation

### DIFF
--- a/pyearth/_forward.pyx
+++ b/pyearth/_forward.pyx
@@ -270,7 +270,9 @@ cdef class ForwardPasser:
         cdef INDEX_t endspan
         cdef bint linear_dependence
         cdef bint dependent
-        # TODO: Shouldn't there be weights here?
+        # The GCV adjustment is based on the number of observations.
+        # The mse values used below already incorporate sample weights,
+        # so ``self.m`` (the unweighted sample size) is appropriate here.
         cdef FLOAT_t gcv_factor_k_plus_1 = gcv_adjust(k + 1, self.m,
                                                       self.penalty)
         cdef FLOAT_t gcv_factor_k_plus_2 = gcv_adjust(k + 2, self.m,


### PR DESCRIPTION
## Summary
- clarify why the forward pass uses the unweighted sample size when computing GCV factors

## Testing
- `python setup.py build_ext -i` *(fails: longintrepr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867c69e73788331b7e9d01445f42ac8