### PR TITLE
Add build step before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install .[all_tests]
+      - name: Build Cython extensions
+        run: |
+          python setup.py build_ext --inplace --cythonize
+      - name: Run tests
+        run: |
+          pytest -v

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 PYTHON ?= python
 CYTHON ?= cython
-NOSETESTS ?= nosetests
+TEST_RUNNER ?= pytest
 CYTHONSRC=$(wildcard pyearth/*.pyx)
 CSRC=$(CYTHONSRC:.pyx=.c)
 
 inplace: cython
-	$(PYTHON) setup.py build_ext -i
+	$(PYTHON) setup.py build_ext --inplace --cythonize
 
 all: inplace
 
@@ -18,13 +18,13 @@ clean:
 	$(CYTHON) $<
 
 test: inplace
-	$(NOSETESTS) -s pyearth
+	$(TEST_RUNNER) -s pyearth
 
 test-coverage: inplace
-	$(NOSETESTS) -s --with-coverage --cover-html --cover-html-dir=coverage --cover-package=pyearth pyearth
+	$(TEST_RUNNER) --cov=pyearth --cov-report=html pyearth
 
 verbose-test: inplace
-	$(NOSETESTS) -sv pyearth
+	$(TEST_RUNNER) -vv pyearth
 
 conda:
 	conda-build conda-recipe

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ cd py-earth
 sudo python setup.py install
 ```
 
+## Running the Tests
+
+Before running the test suite the Cython extension modules must be built in
+place so that they are importable by `pytest`:
+
+```bash
+pip install .[all_tests]
+python setup.py build_ext --inplace --cythonize
+pytest -v
+```
+
+Running the tests from the repository root ensures compiled extensions such as
+`pyearth._forward` are available on the Python path.
+
 ## Usage
 ```python
 import numpy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ install:
   - "rmdir C:\\cygwin /s /q"
 
   # Install the build and runtime dependencies of the project.
-  - "conda install --quiet --yes six numpy pandas sympy scipy cython nose scikit-learn wheel conda-build"
+  - "conda install --quiet --yes six numpy pandas sympy scipy cython pytest scikit-learn wheel conda-build"
   - "pip install sphinx-gallery"
   - "python setup.py bdist_wheel bdist_wininst"
   - "python setup.py build_ext --inplace --cythonize"
@@ -84,7 +84,7 @@ test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
 
-  - "python -c \"import nose; nose.main()\" -s -v pyearth"
+  - "pytest -v pyearth"
 
     # Move back to the project folder
   - "cd .."


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds Cython extensions before running tests
- switch Makefile test runner to `pytest` and call build step
- document how to run the tests after building extensions
- update AppVeyor to use pytest

## Testing
- `python setup.py build_ext --inplace --cythonize` *(fails: '_basis.pxd:3:0: '_types.pxd' not found')*
- `pytest -q` *(fails: ModuleNotFoundError: no module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_6867c6761c90833193fce68dc228ea88