### PR TITLE
Clarify GCV weighting

### DIFF
--- a/doc/content.rst
+++ b/doc/content.rst
@@ -40,10 +40,12 @@ as a linear combination of two hinge functions and a constant (see below).  Duri
 automatically determines which variables and basis functions to use.  
 The algorithm has two stages.  First, the 
 forward pass searches for terms that locally minimize squared error loss on the training set.  Next, a pruning pass selects a subset of those 
-terms that produces a locally minimal generalized cross-validation (GCV) score.  The GCV 
+terms that produces a locally minimal generalized cross-validation (GCV) score.  The GCV
 score is not actually based on cross-validation, but rather is meant to approximate a true
-cross-validation score by penalizing model complexity.  The final result is a set of basis functions
-that is nonlinear in the original feature space, may include interactions, and is likely to 
+cross-validation score by penalizing model complexity.  When sample weights are provided
+they influence only the mean squared error used in the GCV calculation; the adjustment term
+continues to use the number of samples.  The final result is a set of basis functions
+that is nonlinear in the original feature space, may include interactions, and is likely to
 generalize well.
 
 

--- a/pyearth/_forward.pyx
+++ b/pyearth/_forward.pyx
@@ -270,7 +270,9 @@ cdef class ForwardPasser:
         cdef INDEX_t endspan
         cdef bint linear_dependence
         cdef bint dependent
-        # TODO: Shouldn't there be weights here?
+        # The adjustment term uses the number of training samples.
+        # Sample weights are already reflected in mse_ via
+        # self.outcome.mse(), so no weighting is needed here.
         cdef FLOAT_t gcv_factor_k_plus_1 = gcv_adjust(k + 1, self.m,
                                                       self.penalty)
         cdef FLOAT_t gcv_factor_k_plus_2 = gcv_adjust(k + 2, self.m,

--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -220,7 +220,9 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
     `gcv_` : float
         The generalized cross validation (GCV) score of the model after the
         final linear fit. If sample_weight and/or output_weight are
-        given, this score is weighted appropriately.
+        given, this score is weighted appropriately.  The weighting
+        affects only the mse term; the adjustment factor uses the total
+        number of samples regardless of the weights.
 
     `grsq_` : float
         An r^2 like score based on the GCV. If sample_weight and/or


### PR DESCRIPTION
## Summary
- explain why weights aren't used in the GCV adjustment
- document that the GCV correction uses the raw sample count

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_6867c66310ac83318faa3916944102c5