### PR TITLE
Update changelog for GCV and CPython header

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,6 @@
+Next Release
+============
+
+- Updated GCV factor computation: gcv_adjust factors are computed once per iteration and reused while evaluating candidate terms. This fixes penalty application and speeds up the forward pass.
+- Added `#include "cpython/longintrepr.h"` for Python 3.12 compatibility.
+


### PR DESCRIPTION
## Summary
- document updated GCV factor computation
- mention new CPython header for Python 3.12

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_6867c6507e8c8331b4874696bbcc4050