### PR TITLE
Document Python 3 iteritems fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.5.0 (2017-08-18)
+- Fixed Python 3 dictionary iteration errors by replacing `iteritems`/`itervalues` with `items`/`values`.
+- Regenerated C code using Cython 0.26.
+- Updated tests to match new behavior.


### PR DESCRIPTION
## Summary
- document dictionary iteration fixes and regen'd C files

## Testing
- `make test` *(fails: longintrepr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867c6744b8483318a7f8525fcd71ad5