### PR TITLE
Switch tests from nose to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
   - sudo ln -s /run/shm /dev/shm
 # Install packages
 install:
-  - conda install --yes cython numpy scipy matplotlib nose dateutil pandas patsy statsmodels scikit-learn sympy
+  - conda install --yes cython numpy scipy matplotlib pytest dateutil pandas patsy statsmodels scikit-learn sympy
   - python setup.py build_ext --inplace --cythonize
-script: nosetests -s -v pyearth
+script: pytest -s -v pyearth

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 CYTHON ?= cython
-NOSETESTS ?= nosetests
+PYTEST ?= pytest
 CYTHONSRC=$(wildcard pyearth/*.pyx)
 CSRC=$(CYTHONSRC:.pyx=.c)
 
@@ -18,13 +18,13 @@ clean:
 	$(CYTHON) $<
 
 test: inplace
-	$(NOSETESTS) -s pyearth
+        $(PYTEST) -s pyearth
 
 test-coverage: inplace
-	$(NOSETESTS) -s --with-coverage --cover-html --cover-html-dir=coverage --cover-package=pyearth pyearth
+        $(PYTEST) --cov=pyearth --cov-report=html
 
 verbose-test: inplace
-	$(NOSETESTS) -sv pyearth
+        $(PYTEST) -vv pyearth
 
 conda:
 	conda-build conda-recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ install:
   - "rmdir C:\\cygwin /s /q"
 
   # Install the build and runtime dependencies of the project.
-  - "conda install --quiet --yes six numpy pandas sympy scipy cython nose scikit-learn wheel conda-build"
+  - "conda install --quiet --yes six numpy pandas sympy scipy cython pytest scikit-learn wheel conda-build"
   - "pip install sphinx-gallery"
   - "python setup.py bdist_wheel bdist_wininst"
   - "python setup.py build_ext --inplace --cythonize"
@@ -84,7 +84,7 @@ test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
 
-  - "python -c \"import nose; nose.main()\" -s -v pyearth"
+  - "python -m pytest -v pyearth"
 
     # Move back to the project folder
   - "cd .."

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ requirements:
     - cython
     - numpy
     - scikit-learn
-    - nose
+    - pytest
     - six
   run:
     - python
@@ -26,7 +26,7 @@ test:
     - numpy
     - scipy
     - scikit-learn
-    - nose
+    - pytest
   imports:
     - pyearth
 

--- a/conda-recipe/run_test.py
+++ b/conda-recipe/run_test.py
@@ -1,8 +1,8 @@
 import pyearth
-import nose
+import pytest
 import os
 
 pyearth_dir = os.path.dirname(
     os.path.abspath(pyearth.__file__))
 os.chdir(pyearth_dir)
-nose.run(module=pyearth)
+pytest.main(["-v", "pyearth"])

--- a/pyearth/test/basis/__init__.py
+++ b/pyearth/test/basis/__init__.py
@@ -1,6 +1,5 @@
 import pickle
 import os
-from nose.tools import assert_true, assert_false, assert_equal
 
 import numpy
 

--- a/pyearth/test/basis/test_basis.py
+++ b/pyearth/test/basis/test_basis.py
@@ -1,7 +1,6 @@
 import pickle
 import numpy
-
-from nose.tools import assert_equal, assert_true
+from numpy.testing import assert_equal
 
 from .base import BaseContainer
 from pyearth._basis import (HingeBasisFunction, SmoothedHingeBasisFunction,
@@ -46,7 +45,7 @@ def test_smooth_knots():
     assert_equal(knots[cnt.bf1], (0.0, 2.25))
     assert_equal(knots[cnt.bf2], (0.55, 1.25))
     assert_equal(knots[cnt.bf3], (0.6,  1.5))
-    assert_true(cnt.bf4 not in knots)
+    assert cnt.bf4 not in knots
     assert_equal(knots[cnt.bf5], (1.25, 2.25))
 
 
@@ -56,16 +55,16 @@ def test_smooth():
     smooth_basis = cnt.basis.smooth(X)
     for bf, smooth_bf in zip(cnt.basis, smooth_basis):
         if type(bf) is HingeBasisFunction:
-            assert_true(type(smooth_bf) is SmoothedHingeBasisFunction)
+            assert type(smooth_bf) is SmoothedHingeBasisFunction
         elif type(bf) is ConstantBasisFunction:
-            assert_true(type(smooth_bf) is ConstantBasisFunction)
+            assert type(smooth_bf) is ConstantBasisFunction
         elif type(bf) is LinearBasisFunction:
-            assert_true(type(smooth_bf) is LinearBasisFunction)
+            assert type(smooth_bf) is LinearBasisFunction
         else:
             raise AssertionError('Basis function is of an unexpected type.')
-        assert_true(type(smooth_bf) in {SmoothedHingeBasisFunction,
-                                        ConstantBasisFunction,
-                                        LinearBasisFunction})
+        assert type(smooth_bf) in {SmoothedHingeBasisFunction,
+                                   ConstantBasisFunction,
+                                   LinearBasisFunction}
         if bf.has_knot():
             assert_equal(bf.get_knot(), smooth_bf.get_knot())
 
@@ -78,4 +77,4 @@ def test_add():
 def test_pickle_compat():
     cnt = Container()
     basis_copy = pickle.loads(pickle.dumps(cnt.basis))
-    assert_true(cnt.basis == basis_copy)
+    assert cnt.basis == basis_copy

--- a/pyearth/test/basis/test_constant.py
+++ b/pyearth/test/basis/test_constant.py
@@ -1,8 +1,6 @@
 import pickle
 import numpy
 
-from nose.tools import assert_true, assert_false
-
 from .base import BaseContainer
 from pyearth._types import BOOL
 from pyearth._basis import ConstantBasisFunction
@@ -20,9 +18,9 @@ def test_apply():
     m, _ = cnt.X.shape
     missing = numpy.zeros_like(cnt.X, dtype=BOOL)
     B = numpy.empty(shape=(m, 10))
-    assert_false(numpy.all(B[:, 0] == 1))
+    assert not numpy.all(B[:, 0] == 1)
     cnt.bf.apply(cnt.X, missing, B[:, 0])
-    assert_true(numpy.all(B[:, 0] == 1))
+    assert numpy.all(B[:, 0] == 1)
 
 
 def test_deriv():
@@ -32,17 +30,17 @@ def test_deriv():
     b = numpy.empty(shape=m)
     j = numpy.empty(shape=m)
     cnt.bf.apply_deriv(cnt.X, missing, b, j, 1)
-    assert_true(numpy.all(b == 1))
-    assert_true(numpy.all(j == 0))
+    assert numpy.all(b == 1)
+    assert numpy.all(j == 0)
 
 
 def test_pickle_compatibility():
     cnt = Container()
     bf_copy = pickle.loads(pickle.dumps(cnt.bf))
-    assert_true(cnt.bf == bf_copy)
+    assert cnt.bf == bf_copy
 
 
 def test_smoothed_version():
     cnt = Container()
     smoothed = cnt.bf._smoothed_version(None, {}, {})
-    assert_true(type(smoothed) is ConstantBasisFunction)
+    assert type(smoothed) is ConstantBasisFunction

--- a/pyearth/test/basis/test_hinge.py
+++ b/pyearth/test/basis/test_hinge.py
@@ -1,7 +1,6 @@
 import pickle
 import numpy
-
-from nose.tools import assert_equal, assert_true
+from numpy.testing import assert_equal
 
 from .base import BaseContainer
 from pyearth._types import BOOL
@@ -60,7 +59,7 @@ def test_degree():
 def test_pickle_compatibility():
     cnt = Container()
     bf_copy = pickle.loads(pickle.dumps(cnt.bf))
-    assert_true(cnt.bf == bf_copy)
+    assert cnt.bf == bf_copy
 
 
 def test_smoothed_version():
@@ -70,8 +69,8 @@ def test_smoothed_version():
     smoothed = cnt.bf._smoothed_version(cnt.parent, knot_dict,
                                         translation)
 
-    assert_true(type(smoothed) is SmoothedHingeBasisFunction)
-    assert_true(translation[cnt.parent] is smoothed.get_parent())
+    assert type(smoothed) is SmoothedHingeBasisFunction
+    assert translation[cnt.parent] is smoothed.get_parent()
     assert_equal(smoothed.get_knot_minus(), 0.5)
     assert_equal(smoothed.get_knot_plus(), 1.5)
     assert_equal(smoothed.get_knot(), cnt.bf.get_knot())

--- a/pyearth/test/basis/test_linear.py
+++ b/pyearth/test/basis/test_linear.py
@@ -1,7 +1,6 @@
 import pickle
 import numpy
-
-from nose.tools import assert_equal, assert_true
+from numpy.testing import assert_equal
 
 from .base import BaseContainer
 from pyearth._types import BOOL
@@ -22,7 +21,7 @@ def test_apply():
     missing = numpy.zeros_like(cnt.X, dtype=BOOL)
     B = numpy.ones(shape=(m, 10))
     cnt.bf.apply(cnt.X, missing, B[:, 0])
-    assert_true(numpy.all(B[:, 0] == cnt.X[:, 1]))
+    assert numpy.all(B[:, 0] == cnt.X[:, 1])
 
 
 def test_apply_deriv():
@@ -44,12 +43,12 @@ def test_degree():
 def test_pickle_compatibility():
     cnt = Container()
     bf_copy = pickle.loads(pickle.dumps(cnt.bf))
-    assert_true(cnt.bf == bf_copy)
+    assert cnt.bf == bf_copy
 
 
 def test_smoothed_version():
     cnt = Container()
     translation = {cnt.parent: cnt.parent._smoothed_version(None, {}, {})}
     smoothed = cnt.bf._smoothed_version(cnt.parent, {}, translation)
-    assert_true(isinstance(smoothed, LinearBasisFunction))
+    assert isinstance(smoothed, LinearBasisFunction)
     assert_equal(smoothed.get_variable(), cnt.bf.get_variable())

--- a/pyearth/test/basis/test_missingness.py
+++ b/pyearth/test/basis/test_missingness.py
@@ -1,7 +1,6 @@
 import pickle
 import numpy
-
-from nose.tools import assert_equal, assert_true
+from numpy.testing import assert_equal
 
 from .base import BaseContainer
 from pyearth._types import BOOL
@@ -71,7 +70,7 @@ def test_degree():
 def test_pickle_compatibility():
     cnt = Container()
     bf_copy = pickle.loads(pickle.dumps(cnt.bf))
-    assert_true(cnt.bf == bf_copy)
+    assert cnt.bf == bf_copy
 
 #
 # def test_smoothed_version():

--- a/pyearth/test/basis/test_smoothed_hinge.py
+++ b/pyearth/test/basis/test_smoothed_hinge.py
@@ -1,7 +1,6 @@
 import pickle
 import numpy
-
-from nose.tools import assert_equal
+from numpy.testing import assert_equal
 
 from .base import BaseContainer
 from pyearth._types import BOOL

--- a/pyearth/test/test_export.py
+++ b/pyearth/test/test_export.py
@@ -2,7 +2,7 @@ from pyearth._basis import (Basis, ConstantBasisFunction, HingeBasisFunction,
                             LinearBasisFunction)
 from pyearth.export import export_python_function, export_python_string,\
     export_sympy
-from nose.tools import assert_almost_equal
+from numpy.testing import assert_almost_equal
 import numpy
 import six
 from pyearth import Earth

--- a/pyearth/test/test_forward.py
+++ b/pyearth/test/test_forward.py
@@ -6,8 +6,7 @@ Created on Feb 16, 2013
 
 import os
 import numpy
-
-from nose.tools import assert_equal
+from numpy.testing import assert_equal
 
 from pyearth._forward import ForwardPasser
 from pyearth._basis import (Basis, ConstantBasisFunction,

--- a/pyearth/test/test_knot_search.py
+++ b/pyearth/test/test_knot_search.py
@@ -6,9 +6,8 @@ from pyearth._knot_search import (MultipleOutcomeDependentData,
                                   knot_search,
                                   SingleWeightDependentData,
                                   SingleOutcomeDependentData)
-from nose.tools import assert_equal
 import numpy as np
-from numpy.testing.utils import assert_almost_equal, assert_array_equal
+from numpy.testing import assert_equal, assert_almost_equal, assert_array_equal
 from scipy.linalg import qr
 
 

--- a/pyearth/test/test_pruning.py
+++ b/pyearth/test/test_pruning.py
@@ -9,5 +9,5 @@ class Test(object):
         pass
 
 if __name__ == '__main__':
-    import nose
-    nose.run(argv=[__file__, '-s', '-v'])
+    import pytest
+    pytest.main(['-v', __file__])

--- a/pyearth/test/test_util.py
+++ b/pyearth/test/test_util.py
@@ -9,5 +9,5 @@ class TestUtil(object):
         pass
 
 if __name__ == '__main__':
-    import nose
-    nose.run(argv=[__file__, '-s', '-v'])
+    import pytest
+    pytest.main(['-v', __file__])

--- a/pyearth/test/testing_utils.py
+++ b/pyearth/test/testing_utils.py
@@ -1,7 +1,7 @@
 import os
 from functools import wraps
-from nose import SkipTest
-from nose.tools import assert_almost_equal
+import pytest
+from numpy.testing import assert_almost_equal
 from distutils.version import LooseVersion
 import sys
 
@@ -13,8 +13,8 @@ def if_environ_has(var_name):
             if var_name in os.environ:
                 return func(*args, **kwargs)
             else:
-                raise SkipTest('Only run if %s environment variable is '
-                               'defined.' % var_name)
+                pytest.skip('Only run if %s environment variable is '
+                            'defined.' % var_name)
         return run_test
     return if_environ
 
@@ -22,7 +22,7 @@ def if_platform_not_win_32(func):
     @wraps(func)
     def run_test(*args, **kwargs):
         if sys.platform == 'win32':
-            raise SkipTest('Skip for 32 bit Windows platforms.')
+            pytest.skip('Skip for 32 bit Windows platforms.')
         else:
             return func(*args, **kwargs)
     return run_test
@@ -37,8 +37,8 @@ def if_sklearn_version_greater_than_or_equal_to(min_version):
         def run_test(*args, **kwargs):
             import sklearn
             if LooseVersion(sklearn.__version__) < LooseVersion(min_version):
-                raise SkipTest('sklearn version less than %s' %
-                               str(min_version))
+                pytest.skip('sklearn version less than %s' %
+                           str(min_version))
             else:
                 return func(*args, **kwargs)
         return run_test
@@ -53,7 +53,7 @@ def if_statsmodels(func):
         try:
             import statsmodels
         except ImportError:
-            raise SkipTest('statsmodels not available.')
+            pytest.skip('statsmodels not available.')
         else:
             return func(*args, **kwargs)
     return run_test
@@ -67,7 +67,7 @@ def if_pandas(func):
         try:
             import pandas
         except ImportError:
-            raise SkipTest('pandas not available.')
+            pytest.skip('pandas not available.')
         else:
             return func(*args, **kwargs)
     return run_test
@@ -80,7 +80,7 @@ def if_sympy(func):
         try:
             from sympy import Symbol, Add, Mul, Max, RealNumber, Piecewise, sympify, Pow, And, lambdify
         except ImportError:
-            raise SkipTest('sympy not available.')
+            pytest.skip('sympy not available.')
         else:
             return func(*args, **kwargs)
     return run_test
@@ -95,7 +95,7 @@ def if_patsy(func):
         try:
             import patsy
         except ImportError:
-            raise SkipTest('patsy not available.')
+            pytest.skip('patsy not available.')
         else:
             return func(*args, **kwargs)
     return run_test


### PR DESCRIPTION
## Summary
- replace nose tools with pytest and numpy.testing
- update CI configs and Makefile to use pytest
- switch test decorators to `pytest.skip`
- update conda recipe to use pytest

## Testing
- `python setup.py build_ext --inplace --cythonize` *(fails: '_types.pxd' not found)*
- `pytest -k nothing` *(fails: 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6867c63f96b483319795c4d59e9ac4bb