### PR TITLE
Fix string type checks

### DIFF
--- a/pyearth/_pruning.pyx
+++ b/pyearth/_pruning.pyx
@@ -38,7 +38,7 @@ cdef class PruningPasser:
 
         # feature importance
         feature_importance_criteria = kwargs.get("feature_importance_type", [])
-        if isinstance(feature_importance_criteria, basestring):
+        if isinstance(feature_importance_criteria, str):
             feature_importance_criteria = [feature_importance_criteria]
         self.feature_importance = dict()
         for criterion in feature_importance_criteria:

--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -589,11 +589,7 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
             self.xlabels_ = xlabels
         if self.feature_importance_type is not None:
             feature_importance_type = self.feature_importance_type
-            try:
-                is_str = isinstance(feature_importance_type, basestring)
-            except NameError:
-                is_str = isinstance(feature_importance_type, str)
-            if is_str:
+            if isinstance(feature_importance_type, str):
                 feature_importance_type = [feature_importance_type]
             for k in feature_importance_type:
                 if k not in FEAT_IMP_CRITERIA:


### PR DESCRIPTION
## Summary
- replace deprecated `basestring` checks with `str`
- remove obsolete Python 2 compatibility try/except

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*
- `make inplace` *(fails: cython not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c63a86548331bc5e4512ae708583