### PR TITLE
Update tests for Python 3

### DIFF
--- a/pyearth/test/basis/test_basis.py
+++ b/pyearth/test/basis/test_basis.py
@@ -11,7 +11,7 @@ from pyearth._basis import (HingeBasisFunction, SmoothedHingeBasisFunction,
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.basis = Basis(self.X.shape[1])
         self.parent = ConstantBasisFunction()
         self.bf1 = HingeBasisFunction(self.parent, 1.0, 10, 1, False)

--- a/pyearth/test/basis/test_constant.py
+++ b/pyearth/test/basis/test_constant.py
@@ -11,7 +11,7 @@ from pyearth._basis import ConstantBasisFunction
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.bf = ConstantBasisFunction()
 
 

--- a/pyearth/test/basis/test_hinge.py
+++ b/pyearth/test/basis/test_hinge.py
@@ -12,7 +12,7 @@ from pyearth._basis import (HingeBasisFunction, SmoothedHingeBasisFunction,
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.parent = ConstantBasisFunction()
         self.bf = HingeBasisFunction(self.parent, 1.0, 10, 1, False)
 

--- a/pyearth/test/basis/test_linear.py
+++ b/pyearth/test/basis/test_linear.py
@@ -11,7 +11,7 @@ from pyearth._basis import LinearBasisFunction, ConstantBasisFunction
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.parent = ConstantBasisFunction()
         self.bf = LinearBasisFunction(self.parent, 1)
 

--- a/pyearth/test/basis/test_missingness.py
+++ b/pyearth/test/basis/test_missingness.py
@@ -12,7 +12,7 @@ from pyearth._basis import (
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.parent = ConstantBasisFunction()
         self.bf = MissingnessBasisFunction(self.parent, 1, True)
         self.child = HingeBasisFunction(self.bf, 1.0, 10, 1, False)

--- a/pyearth/test/basis/test_smoothed_hinge.py
+++ b/pyearth/test/basis/test_smoothed_hinge.py
@@ -11,7 +11,7 @@ from pyearth._basis import SmoothedHingeBasisFunction, ConstantBasisFunction
 class Container(BaseContainer):
 
     def __init__(self):
-        super(Container, self).__init__()
+        super().__init__()
         self.parent = ConstantBasisFunction()
         self.bf1 = SmoothedHingeBasisFunction(self.parent,
                                               1.0, 0.0, 3.0, 10, 1,

--- a/pyearth/test/test_export.py
+++ b/pyearth/test/test_export.py
@@ -4,7 +4,6 @@ from pyearth.export import export_python_function, export_python_string,\
     export_sympy
 from nose.tools import assert_almost_equal
 import numpy
-import six
 from pyearth import Earth
 from pyearth._types import BOOL
 from pyearth.test.testing_utils import if_pandas,\
@@ -49,7 +48,7 @@ def test_export_python_string():
     for smooth in (True, False):
         model = Earth(penalty=1, smooth=smooth, max_degree=2).fit(X, y)
         export_model = export_python_string(model, 'my_test_model')
-        six.exec_(export_model, globals())
+        exec(export_model, globals())
         for exp_pred, model_pred in zip(model.predict(X), my_test_model(X)):
             assert_almost_equal(exp_pred, model_pred)
 


### PR DESCRIPTION
## Summary
- update exec usage in `test_export.py`
- drop old `super(Class, self)` calls in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_6867c62de7288331b9d78cf201cd0d62