### PR TITLE
Use explicit int64 type in Cython headers

### DIFF
--- a/pyearth/_types.pxd
+++ b/pyearth/_types.pxd
@@ -1,5 +1,5 @@
 cimport numpy as cnp
 ctypedef cnp.float64_t FLOAT_t
-ctypedef cnp.int_t INT_t
+ctypedef cnp.int64_t INT_t
 ctypedef cnp.intp_t INDEX_t
 ctypedef cnp.uint8_t BOOL_t

--- a/pyearth/_types.pyx
+++ b/pyearth/_types.pyx
@@ -1,5 +1,5 @@
 import numpy as np
 FLOAT = np.float64
-INT = np.int
+INT = np.int64
 INDEX = np.intp
 BOOL = np.uint8


### PR DESCRIPTION
## Summary
- use `cnp.int64_t` for `INT_t` type
- use `numpy.int64` in Python type definitions

## Testing
- `python setup.py build_ext --inplace --cythonize` *(fails: Cython CompileError)*

------
https://chatgpt.com/codex/tasks/task_e_6867cb0edb9c8331afaf488ac9eef0d0