### PR TITLE
Replace basestring checks with str

### DIFF
--- a/pyearth/_pruning.pyx
+++ b/pyearth/_pruning.pyx
@@ -38,7 +38,7 @@ cdef class PruningPasser:
 
         # feature importance
         feature_importance_criteria = kwargs.get("feature_importance_type", [])
-        if isinstance(feature_importance_criteria, basestring):
+        if isinstance(feature_importance_criteria, str):
             feature_importance_criteria = [feature_importance_criteria]
         self.feature_importance = dict()
         for criterion in feature_importance_criteria:

--- a/pyearth/earth.py
+++ b/pyearth/earth.py
@@ -589,10 +589,7 @@ class Earth(BaseEstimator, RegressorMixin, TransformerMixin):
             self.xlabels_ = xlabels
         if self.feature_importance_type is not None:
             feature_importance_type = self.feature_importance_type
-            try:
-                is_str = isinstance(feature_importance_type, basestring)
-            except NameError:
-                is_str = isinstance(feature_importance_type, str)
+            is_str = isinstance(feature_importance_type, str)
             if is_str:
                 feature_importance_type = [feature_importance_type]
             for k in feature_importance_type:


### PR DESCRIPTION
## Summary
- update `Earth.fit` to check for `str` directly
- update pruning module to use `str` for feature importance criteria

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_6867c626012483318eddd1c6d9066170