### PR TITLE
Replace deprecated iteritems/itervalues calls

### DIFF
--- a/pyearth/_basis.pyx
+++ b/pyearth/_basis.pyx
@@ -986,7 +986,7 @@ cdef class Basis:
         cdef dict anova = self.anova_decomp()
         cdef dict intermediate = {}
         cdef dict result = {}
-        for vars, bfs in anova.iteritems():
+        for vars, bfs in anova.items():
             intermediate[vars] = {}
             for var in vars:
                 intermediate[vars][var] = []
@@ -995,8 +995,8 @@ cdef class Basis:
                     variable = bf.get_variable()
                     knot = bf.get_knot()
                     intermediate[vars][variable].append((bf, knot))
-        for d in intermediate.itervalues():
-            for var, lst in d.iteritems():
+        for d in intermediate.values():
+            for var, lst in d.items():
                 lst.sort(key=lambda x: x[1])
                 prev_minus = mins[var]
                 prev = prev_minus

--- a/pyearth/test/test_earth.py
+++ b/pyearth/test/test_earth.py
@@ -259,7 +259,7 @@ def test_pathological_cases():
                           'endspan': 1,
                           'check_every': 1,
                           'sample_weight': 'issue_50_weight.csv'}}
-    for case, settings in cases.iteritems():
+    for case, settings in cases.items():
         data = pandas.read_csv(os.path.join(directory, case + '.csv'))
         y = data['y']
         del data['y']


### PR DESCRIPTION
## Summary
- update old Python dict iteration methods
- keep tests compatible with Python 3

## Testing
- `python setup.py build_ext -i` *(fails: longintrepr.h missing; build requires older Python)*

------
https://chatgpt.com/codex/tasks/task_e_6867c62482308331b382dc137222ede0