### PR TITLE
Switch test runner to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
   - sudo ln -s /run/shm /dev/shm
 # Install packages
 install:
-  - conda install --yes cython numpy scipy matplotlib nose dateutil pandas patsy statsmodels scikit-learn sympy
+  - conda install --yes cython numpy scipy matplotlib nose dateutil pandas patsy statsmodels scikit-learn sympy pytest
   - python setup.py build_ext --inplace --cythonize
-script: nosetests -s -v pyearth
+script: pytest -s -v pyearth

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 CYTHON ?= cython
-NOSETESTS ?= nosetests
+PYTEST ?= pytest
 CYTHONSRC=$(wildcard pyearth/*.pyx)
 CSRC=$(CYTHONSRC:.pyx=.c)
 
@@ -18,13 +18,13 @@ clean:
 	$(CYTHON) $<
 
 test: inplace
-	$(NOSETESTS) -s pyearth
+        $(PYTEST) -s pyearth
 
 test-coverage: inplace
-	$(NOSETESTS) -s --with-coverage --cover-html --cover-html-dir=coverage --cover-package=pyearth pyearth
+        $(PYTEST) -s --cov=pyearth --cov-report=html --cov-report=term pyearth
 
 verbose-test: inplace
-	$(NOSETESTS) -sv pyearth
+        $(PYTEST) -sv pyearth
 
 conda:
 	conda-build conda-recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ install:
   - "rmdir C:\\cygwin /s /q"
 
   # Install the build and runtime dependencies of the project.
-  - "conda install --quiet --yes six numpy pandas sympy scipy cython nose scikit-learn wheel conda-build"
+  - "conda install --quiet --yes six numpy pandas sympy scipy cython nose pytest scikit-learn wheel conda-build"
   - "pip install sphinx-gallery"
   - "python setup.py bdist_wheel bdist_wininst"
   - "python setup.py build_ext --inplace --cythonize"
@@ -84,7 +84,7 @@ test_script:
   - "mkdir empty_folder"
   - "cd empty_folder"
 
-  - "python -c \"import nose; nose.main()\" -s -v pyearth"
+  - "pytest -s -v pyearth"
 
     # Move back to the project folder
   - "cd .."

--- a/conda-recipe/run_test.py
+++ b/conda-recipe/run_test.py
@@ -1,8 +1,8 @@
 import pyearth
-import nose
+import pytest
 import os
 
 pyearth_dir = os.path.dirname(
     os.path.abspath(pyearth.__file__))
 os.chdir(pyearth_dir)
-nose.run(module=pyearth)
+pytest.main([pyearth_dir])

--- a/pyearth/test/test_pruning.py
+++ b/pyearth/test/test_pruning.py
@@ -9,5 +9,5 @@ class Test(object):
         pass
 
 if __name__ == '__main__':
-    import nose
-    nose.run(argv=[__file__, '-s', '-v'])
+    import pytest
+    pytest.main([__file__, '-s', '-v'])

--- a/pyearth/test/test_util.py
+++ b/pyearth/test/test_util.py
@@ -9,5 +9,5 @@ class TestUtil(object):
         pass
 
 if __name__ == '__main__':
-    import nose
-    nose.run(argv=[__file__, '-s', '-v'])
+    import pytest
+    pytest.main([__file__, '-s', '-v'])


### PR DESCRIPTION
## Summary
- use `pytest` in Makefile
- switch CI configs from `nosetests` to `pytest`
- update conda test script
- update local test modules to invoke `pytest`

## Testing
- `pytest -k '' -s` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_686803ce1688833188425b70f024769a