### PR TITLE
Update conda recipe for Python 3

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -7,26 +7,24 @@ source:
 
 requirements:
   build:
-    - python
+    - python >=3
     - setuptools
     - cython
     - numpy
     - scikit-learn
-    - nose
-    - six
+
   run:
-    - python
+    - python >=3
     - numpy
     - scipy
     - scikit-learn
-    - six
 
+  
 test:
   requires:
     - numpy
     - scipy
     - scikit-learn
-    - nose
   imports:
     - pyearth
 


### PR DESCRIPTION
## Summary
- update conda recipe to require Python 3
- remove `nose` and `six` from build, run and test requirements

## Testing
- `nosetests -s pyearth` *(fails: ModuleNotFoundError: No module named 'imp')*
- `pytest pyearth` *(fails: 15 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68682da64adc8331bcdb7dc7814c185a