### PR TITLE
Drop Python2 markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "numpy"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -118,9 +118,6 @@ def setup_package():
                         'Operating System :: Unix',
                         'Programming Language :: Cython',
                         'Programming Language :: Python',
-                        'Programming Language :: Python :: 2',
-                        'Programming Language :: Python :: 2.6',
-                        'Programming Language :: Python :: 2.7',
                         'Programming Language :: Python :: 3',
                         'Programming Language :: Python :: 3.4',
                         'Programming Language :: Python :: 3.5',
@@ -130,7 +127,6 @@ def setup_package():
         'install_requires': [
             'scipy >= 0.16',
             'scikit-learn >= 0.16',
-            'six'
             ],
         'extras_require': {'docs': ['sphinx_gallery'],
                            'dev': ['cython'],


### PR DESCRIPTION
## Summary
- prune Python 2 classifiers and `six` from setup.py
- add a minimal `pyproject.toml` for PEP 517 builds

## Testing
- `nosetests -s pyearth` *(fails: ModuleNotFoundError: No module named 'imp')*

------
https://chatgpt.com/codex/tasks/task_e_68682dd645cc83319c9f131cb81a08ef