### PR TITLE
Replace deprecated numpy int/float aliases

### DIFF
--- a/pyearth/_forward.pyx
+++ b/pyearth/_forward.pyx
@@ -108,10 +108,10 @@ cdef class ForwardPasser:
             content = FastHeapContent(idx=0)
             heappush(self.fast_heap, content)
             
-        self.mwork = np.empty(shape=self.m, dtype=np.int)
+        self.mwork = np.empty(shape=self.m, dtype=int)
         
         self.B = np.ones(
-            shape=(self.m, self.max_terms + 4), order='F', dtype=np.float)
+            shape=(self.m, self.max_terms + 4), order='F', dtype=float)
         self.basis.transform(self.X, self.missing, self.B[:,0:1])
         
         if self.endspan < 0:
@@ -172,7 +172,7 @@ cdef class ForwardPasser:
             <cnp.ndarray[FLOAT_t, ndim = 2] > self.X)
         cdef ConstantBasisFunction root_basis_function = self.basis[0]
         for variable in range(self.n):
-            order = np.argsort(X[:, variable])[::-1].astype(np.int)
+            order = np.argsort(X[:, variable])[::-1].astype(int)
             if root_basis_function.valid_knots(B[order, 0], X[order, variable],
                                                variable, self.check_every,
                                                self.endspan, self.minspan,

--- a/pyearth/_pruning.pyx
+++ b/pyearth/_pruning.pyx
@@ -29,7 +29,7 @@ cdef class PruningPasser:
         self.sample_weight = sample_weight
         self.verbose = verbose
         self.basis = basis
-        self.B = np.empty(shape=(self.m, len(self.basis) + 1), dtype=np.float)
+        self.B = np.empty(shape=(self.m, len(self.basis) + 1), dtype=float)
         self.penalty = kwargs.get('penalty', 3.0)
         if sample_weight.shape[1] == 1:
             y_avg = np.average(self.y, weights=sample_weight[:,0], axis=0)

--- a/pyearth/_types.pyx
+++ b/pyearth/_types.pyx
@@ -1,5 +1,5 @@
 import numpy as np
 FLOAT = np.float64
-INT = np.int
+INT = int
 INDEX = np.intp
 BOOL = np.uint8


### PR DESCRIPTION
## Summary
- modernize dtype usage by replacing `np.int` and `np.float`
- use built-in `int`/`float` when allocating arrays in cython modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyearth._forward')*

------
https://chatgpt.com/codex/tasks/task_e_68682dd4e6988331a44c11fc8faa6bcb