### PR TITLE
Remove stray debug print

### DIFF
--- a/pyearth/_qr.pyx
+++ b/pyearth/_qr.pyx
@@ -198,8 +198,7 @@ cdef class Householder:
         cdef int ldc = C.strides[1] // C.itemsize
         cdef FLOAT_t * work = <FLOAT_t *> &(self.work[0,0])
         cdef int ldwork = self.m
-        print C.shape
-        dlarfb(&side, &trans, &direct, &storev, &M, &N, &K, 
+        dlarfb(&side, &trans, &direct, &storev, &M, &N, &K,
                V, &ldv, T, &ldt, C_arg, &ldc, work, &ldwork)
         
     cpdef void left_apply_transpose(Householder self, FLOAT_t[::1, :] C):


### PR DESCRIPTION
## Summary
- clean up debug output in `pyearth/_qr.pyx`

## Testing
- `python setup.py build_ext -i` *(fails: longintrepr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68682d9268848331b5584a9a1b6b5b92