### PR TITLE
Fix setup.cfg description_file key

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,5 @@ tag_prefix=
 parentdir_prefix = py-earth
 
 [metadata]
-description-file = description.md
+description_file = description.md
 license_file = LICENSE.txt


### PR DESCRIPTION
## Summary
- update `description-file` to `description_file` in `setup.cfg`
- run `python setup.py --version` to confirm the warning is gone

## Testing
- `python setup.py --version`

------
https://chatgpt.com/codex/tasks/task_e_68684fd9cef08331a44ac7eb06f8e779