### PR TITLE
Remove six from conda recipe and CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ install:
   - "rmdir C:\\cygwin /s /q"
 
   # Install the build and runtime dependencies of the project.
-  - "conda install --quiet --yes six numpy pandas sympy scipy cython nose scikit-learn wheel conda-build"
+  - "conda install --quiet --yes numpy pandas sympy scipy cython nose scikit-learn wheel conda-build"
   - "pip install sphinx-gallery"
   - "python setup.py bdist_wheel bdist_wininst"
   - "python setup.py build_ext --inplace --cythonize"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -13,13 +13,11 @@ requirements:
     - numpy
     - scikit-learn
     - nose
-    - six
   run:
     - python
     - numpy
     - scipy
     - scikit-learn
-    - six
 
 test:
   requires:


### PR DESCRIPTION
## Summary
- drop `six` from build/run requirements in conda recipe
- update Appveyor to stop installing `six`

## Testing
- `python setup.py build_ext --inplace` *(fails: longintrepr.h missing)*
- `nosetests -s pyearth` *(fails: ModuleNotFoundError: No module named 'imp')*

------
https://chatgpt.com/codex/tasks/task_e_686850c72ed8833190a9486db43955f3